### PR TITLE
Authorisation

### DIFF
--- a/LeaderboardBackend.Test/Categories.cs
+++ b/LeaderboardBackend.Test/Categories.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using NUnit.Framework;
 using System.Net;
 using System.Net.Http;
-using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace LeaderboardBackend.Test;
@@ -16,10 +15,6 @@ internal class Categories
 {
 	private static TestApiFactory Factory = null!;
 	private static HttpClient ApiClient = null!;
-	private static JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions
-	{
-		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-	};
 	private static string? Jwt;
 
 	[SetUp]
@@ -27,7 +22,7 @@ internal class Categories
 	{
 		Factory = new TestApiFactory();
 		ApiClient = Factory.CreateClient();
-		Jwt = UserHelpers.Login(ApiClient, Factory.GetAdmin().Email, Factory.GetAdmin().Password, JsonSerializerOptions).Result.Token;
+		Jwt = UserHelpers.LoginAdmin(ApiClient).Result.Token;
 	}
 
 	[Test]
@@ -61,8 +56,7 @@ internal class Categories
 			{
 				Body = createLeaderboardBody,
 				Jwt = Jwt,
-			},
-			JsonSerializerOptions
+			}
 		);
 
 		CreateCategoryRequest createCategoryBody = new()
@@ -79,8 +73,7 @@ internal class Categories
 			{
 				Body = createCategoryBody,
 				Jwt = Jwt,
-			},
-			JsonSerializerOptions
+			}
 		);
 
 		Assert.AreEqual(1, createdCategory.PlayersMax);
@@ -91,8 +84,7 @@ internal class Categories
 			new()
 			{
 				Jwt = Jwt,
-			},
-			JsonSerializerOptions
+			}
 		);
 
 		Assert.AreEqual(createdCategory, retrievedCategory);

--- a/LeaderboardBackend.Test/Categories.cs
+++ b/LeaderboardBackend.Test/Categories.cs
@@ -2,10 +2,10 @@ using LeaderboardBackend.Models.Entities;
 using LeaderboardBackend.Models.Requests.Categories;
 using LeaderboardBackend.Models.Requests.Leaderboards;
 using LeaderboardBackend.Test.Lib;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using NUnit.Framework;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Json;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -20,49 +20,80 @@ internal class Categories
 	{
 		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
 	};
+	private static string? Jwt;
 
 	[SetUp]
 	public static void SetUp()
 	{
 		Factory = new TestApiFactory();
 		ApiClient = Factory.CreateClient();
+		Jwt = UserHelpers.Login(ApiClient, Factory.GetAdmin().Email, Factory.GetAdmin().Password, JsonSerializerOptions).Result.Token;
 	}
 
 	[Test]
 	public static async Task GetCategory_NoCategories()
 	{
 		long id = 1;
-		HttpResponseMessage response = await ApiClient.GetAsync($"/api/categories/{id}");
+		HttpRequestMessage request = new(HttpMethod.Get, $"/api/categories/{id}")
+		{
+			Headers =
+			{
+				Authorization = new(JwtBearerDefaults.AuthenticationScheme, Jwt)
+			}
+		};
+		HttpResponseMessage response = await ApiClient.SendAsync(request);
 		Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
 	}
 
 	[Test]
 	public static async Task CreateCategory_GetCategory()
 	{
-		CreateLeaderboardRequest createLeaderboardBody = new() 
+		CreateLeaderboardRequest createLeaderboardBody = new()
 		{
 			Name = Generators.GenerateRandomString(),
 			Slug = Generators.GenerateRandomString(),
 		};
-		HttpResponseMessage createLeaderboardResponse = await ApiClient.PostAsJsonAsync("/api/leaderboards", createLeaderboardBody, JsonSerializerOptions);
-		createLeaderboardResponse.EnsureSuccessStatusCode();
-		Leaderboard createdLeaderboard = await HttpHelpers.ReadFromResponseBody<Leaderboard>(createLeaderboardResponse, JsonSerializerOptions);
-		
-		CreateCategoryRequest createBody = new()
+
+		Leaderboard createdLeaderboard = await HttpHelpers.Post<Leaderboard>(
+			ApiClient,
+			"/api/leaderboards",
+			new()
+			{
+				Body = createLeaderboardBody,
+				Jwt = Jwt,
+			},
+			JsonSerializerOptions
+		);
+
+		CreateCategoryRequest createCategoryBody = new()
 		{
 			Name = Generators.GenerateRandomString(),
 			Slug = Generators.GenerateRandomString(),
 			LeaderboardId = createdLeaderboard.Id,
 		};
-		HttpResponseMessage createResponse = await ApiClient.PostAsJsonAsync("/api/categories", createBody, JsonSerializerOptions);
-		createResponse.EnsureSuccessStatusCode();
-		Category createdCategory = await HttpHelpers.ReadFromResponseBody<Category>(createResponse, JsonSerializerOptions);
+
+		Category createdCategory = await HttpHelpers.Post<Category>(
+			ApiClient,
+			"/api/categories",
+			new()
+			{
+				Body = createCategoryBody,
+				Jwt = Jwt,
+			},
+			JsonSerializerOptions
+		);
 
 		Assert.AreEqual(1, createdCategory.PlayersMax);
 
-		HttpResponseMessage getResponse = await ApiClient.GetAsync($"/api/categories/{createdCategory?.Id}");
-		getResponse.EnsureSuccessStatusCode();
-		Category retrievedCategory = await HttpHelpers.ReadFromResponseBody<Category>(getResponse, JsonSerializerOptions);
+		Category retrievedCategory = await HttpHelpers.Get<Category>(
+			ApiClient,
+			$"/api/categories/{createdCategory?.Id}",
+			new()
+			{
+				Jwt = Jwt,
+			},
+			JsonSerializerOptions
+		);
 
 		Assert.AreEqual(createdCategory, retrievedCategory);
 	}

--- a/LeaderboardBackend.Test/Leaderboards.cs
+++ b/LeaderboardBackend.Test/Leaderboards.cs
@@ -95,7 +95,7 @@ internal class Leaderboards
 		string leaderboardIdQuery = ListToQueryString(leaderboardIds, "ids");
 		HttpResponseMessage getResponse = await ApiClient.GetAsync($"api/leaderboards?{leaderboardIdQuery}");
 		List<Leaderboard> leaderboards = await HttpHelpers.ReadFromResponseBody<List<Leaderboard>>(getResponse);
-		foreach (var leaderboard in leaderboards)
+		foreach (Leaderboard leaderboard in leaderboards)
 		{
 			Assert.IsTrue(createdLeaderboards.Contains(leaderboard));
 			createdLeaderboards.Remove(leaderboard);

--- a/LeaderboardBackend.Test/Lib/HttpHelpers.cs
+++ b/LeaderboardBackend.Test/Lib/HttpHelpers.cs
@@ -11,8 +11,7 @@ namespace LeaderboardBackend.Test.Lib;
 
 internal static class HttpHelpers
 {
-	/// <typeparam name="Body">Object class that defines the POST's request body.</typeparam>
-	/// <typeparam name="Res">Response object class from the POST.</typeparam>
+	/// <typeparam name="Res">Response object class from the GET.</typeparam>
 	public static async Task<Res> Get<Res>(
 		string endpoint,
 		HttpClient client,
@@ -58,6 +57,7 @@ internal static class HttpHelpers
 		return string.Join("&", queryList);
 	}
 
+	// Shep: I don't really like how I've laid the arguments out like this, honestly. Might rework this.
 	private static HttpRequestMessage CreateRequestMessage(
 		string endpoint,
 		HttpMethod method,
@@ -83,6 +83,7 @@ internal static class HttpHelpers
 		return requestMessage; // To be then called with HttpClient.SendAsync(requestMessage);
 	}
 
+	// TODO: Try to have HttpClient be called within this class. Annoying for callers to keep passing it in.
 	private static async Task<Res> Send<Res>(HttpRequestMessage message, HttpClient client, JsonSerializerOptions options)
 	{
 		HttpResponseMessage response = await client.SendAsync(message);

--- a/LeaderboardBackend.Test/Lib/HttpHelpers.cs
+++ b/LeaderboardBackend.Test/Lib/HttpHelpers.cs
@@ -57,7 +57,7 @@ internal static class HttpHelpers
 		return string.Join("&", queryList);
 	}
 
-	// Shep: I don't really like how I've laid the arguments out like this, honestly. Might rework this.
+	// Shep: I don't really like how I've laid the arguments out like this, honestly. Might rework this entire methodology.
 	private static HttpRequestMessage CreateRequestMessage(
 		string endpoint,
 		HttpMethod method,

--- a/LeaderboardBackend.Test/Lib/HttpHelpers.cs
+++ b/LeaderboardBackend.Test/Lib/HttpHelpers.cs
@@ -1,8 +1,9 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Net.Http.Json;
+using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -12,11 +13,35 @@ internal static class HttpHelpers
 {
 	/// <typeparam name="Body">Object class that defines the POST's request body.</typeparam>
 	/// <typeparam name="Res">Response object class from the POST.</typeparam>
-	public static async Task<Res> Post<Body, Res>(string endpoint, Body requestBody, HttpClient httpClient, JsonSerializerOptions options)
+	public static async Task<Res> Get<Res>(
+		string endpoint,
+		HttpClient client,
+		JsonSerializerOptions options,
+		string? jwt = null
+	)
 	{
-		HttpResponseMessage response = await httpClient.PostAsJsonAsync(endpoint, requestBody, options);
-		response.EnsureSuccessStatusCode();
-		return await HttpHelpers.ReadFromResponseBody<Res>(response, options);
+		return await Send<Res>(
+			CreateRequestMessage(endpoint, HttpMethod.Get, options, jwt),
+			client,
+			options
+		);
+	}
+
+	/// <typeparam name="Body">Object class that defines the POST's request body.</typeparam>
+	/// <typeparam name="Res">Response object class from the POST.</typeparam>
+	public static async Task<Res> Post<Body, Res>(
+		string endpoint,
+		Body body,
+		HttpClient client,
+		JsonSerializerOptions options,
+		string? jwt = null
+	)
+	{
+		return await Send<Res>(
+			CreateRequestMessage(endpoint, HttpMethod.Post, options, jwt, body),
+			client,
+			options
+		);
 	}
 
 	public static async Task<T> ReadFromResponseBody<T>(HttpResponseMessage response, JsonSerializerOptions jsonOptions)
@@ -31,5 +56,37 @@ internal static class HttpHelpers
 	{
 		IEnumerable<string> queryList = list.Select(l => $"{key}={l}");
 		return string.Join("&", queryList);
+	}
+
+	private static HttpRequestMessage CreateRequestMessage(
+		string endpoint,
+		HttpMethod method,
+		JsonSerializerOptions options,
+		string? jwt,
+		object? body = null
+	)
+	{
+		HttpRequestMessage requestMessage = new(method, endpoint);
+
+		if (body is not null)
+		{
+			StringContent content = new(JsonSerializer.Serialize(body, options));
+			content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+			requestMessage.Content = content;
+		}
+
+		if (jwt is not null)
+		{
+			requestMessage.Headers.Authorization = new AuthenticationHeaderValue(JwtBearerDefaults.AuthenticationScheme, jwt);
+		}
+
+		return requestMessage; // To be then called with HttpClient.SendAsync(requestMessage);
+	}
+
+	private static async Task<Res> Send<Res>(HttpRequestMessage message, HttpClient client, JsonSerializerOptions options)
+	{
+		HttpResponseMessage response = await client.SendAsync(message);
+		response.EnsureSuccessStatusCode();
+		return await HttpHelpers.ReadFromResponseBody<Res>(response, options);
 	}
 }

--- a/LeaderboardBackend.Test/Lib/HttpHelpers.cs
+++ b/LeaderboardBackend.Test/Lib/HttpHelpers.cs
@@ -14,21 +14,19 @@ internal static class HttpHelpers
 	public static async Task<Res> Get<Res>(
 		HttpClient client,
 		string endpoint,
-		HttpRequestInit init,
-		JsonSerializerOptions options
-	) => await Send<Res>(client, endpoint, init with { Method = HttpMethod.Get }, options);
+		HttpRequestInit init
+	) => await Send<Res>(client, endpoint, init with { Method = HttpMethod.Get });
 
 	public static async Task<Res> Post<Res>(
 		HttpClient client,
 		string endpoint,
-		HttpRequestInit init,
-		JsonSerializerOptions options
-	) => await Send<Res>(client, endpoint, init with { Method = HttpMethod.Post }, options);
+		HttpRequestInit init
+	) => await Send<Res>(client, endpoint, init with { Method = HttpMethod.Post });
 
-	public static async Task<T> ReadFromResponseBody<T>(HttpResponseMessage response, JsonSerializerOptions jsonOptions)
+	public static async Task<T> ReadFromResponseBody<T>(HttpResponseMessage response)
 	{
 		string rawJson = await response.Content.ReadAsStringAsync();
-		T? obj = JsonSerializer.Deserialize<T>(rawJson, jsonOptions);
+		T? obj = JsonSerializer.Deserialize<T>(rawJson, TestInitCommonFields.JsonSerializerOptions);
 		Assert.NotNull(obj);
 		return obj!;
 	}
@@ -36,19 +34,18 @@ internal static class HttpHelpers
 	private static async Task<Res> Send<Res>(
 		HttpClient client,
 		string endpoint,
-		HttpRequestInit init,
-		JsonSerializerOptions options
+		HttpRequestInit init
 	)
 	{
 		HttpResponseMessage response = await client.SendAsync(
 			CreateRequestMessage(
 				endpoint,
 				init,
-				options
+				TestInitCommonFields.JsonSerializerOptions
 			)
 		);
 		response.EnsureSuccessStatusCode();
-		return await HttpHelpers.ReadFromResponseBody<Res>(response, options);
+		return await HttpHelpers.ReadFromResponseBody<Res>(response);
 	}
 
 	private static HttpRequestMessage CreateRequestMessage(

--- a/LeaderboardBackend.Test/Lib/HttpHelpers.cs
+++ b/LeaderboardBackend.Test/Lib/HttpHelpers.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -9,8 +10,17 @@ namespace LeaderboardBackend.Test.Lib;
 
 internal static class HttpHelpers
 {
-	public static async Task<T> ReadFromResponseBody<T>(HttpResponseMessage response, JsonSerializerOptions jsonOptions) 
-	{ 
+	/// <typeparam name="Body">Object class that defines the POST's request body.</typeparam>
+	/// <typeparam name="Res">Response object class from the POST.</typeparam>
+	public static async Task<Res> Post<Body, Res>(string endpoint, Body requestBody, HttpClient httpClient, JsonSerializerOptions options)
+	{
+		HttpResponseMessage response = await httpClient.PostAsJsonAsync(endpoint, requestBody, options);
+		response.EnsureSuccessStatusCode();
+		return await HttpHelpers.ReadFromResponseBody<Res>(response, options);
+	}
+
+	public static async Task<T> ReadFromResponseBody<T>(HttpResponseMessage response, JsonSerializerOptions jsonOptions)
+	{
 		string rawJson = await response.Content.ReadAsStringAsync();
 		T? obj = JsonSerializer.Deserialize<T>(rawJson, jsonOptions);
 		Assert.NotNull(obj);

--- a/LeaderboardBackend.Test/Lib/HttpHelpers.cs
+++ b/LeaderboardBackend.Test/Lib/HttpHelpers.cs
@@ -11,37 +11,19 @@ namespace LeaderboardBackend.Test.Lib;
 
 internal static class HttpHelpers
 {
-	/// <typeparam name="Res">Response object class from the GET.</typeparam>
 	public static async Task<Res> Get<Res>(
-		string endpoint,
 		HttpClient client,
-		JsonSerializerOptions options,
-		string? jwt = null
-	)
-	{
-		return await Send<Res>(
-			CreateRequestMessage(endpoint, HttpMethod.Get, options, jwt),
-			client,
-			options
-		);
-	}
+		string endpoint,
+		HttpRequestInit init,
+		JsonSerializerOptions options
+	) => await Send<Res>(client, endpoint, init with { Method = HttpMethod.Get }, options);
 
-	/// <typeparam name="Body">Object class that defines the POST's request body.</typeparam>
-	/// <typeparam name="Res">Response object class from the POST.</typeparam>
-	public static async Task<Res> Post<Body, Res>(
-		string endpoint,
-		Body body,
+	public static async Task<Res> Post<Res>(
 		HttpClient client,
-		JsonSerializerOptions options,
-		string? jwt = null
-	)
-	{
-		return await Send<Res>(
-			CreateRequestMessage(endpoint, HttpMethod.Post, options, jwt, body),
-			client,
-			options
-		);
-	}
+		string endpoint,
+		HttpRequestInit init,
+		JsonSerializerOptions options
+	) => await Send<Res>(client, endpoint, init with { Method = HttpMethod.Post }, options);
 
 	public static async Task<T> ReadFromResponseBody<T>(HttpResponseMessage response, JsonSerializerOptions jsonOptions)
 	{
@@ -51,43 +33,45 @@ internal static class HttpHelpers
 		return obj!;
 	}
 
-	public static string ListToQueryString<T>(IEnumerable<T> list, string key)
-	{
-		IEnumerable<string> queryList = list.Select(l => $"{key}={l}");
-		return string.Join("&", queryList);
-	}
-
-	// Shep: I don't really like how I've laid the arguments out like this, honestly. Might rework this entire methodology.
-	private static HttpRequestMessage CreateRequestMessage(
+	private static async Task<Res> Send<Res>(
+		HttpClient client,
 		string endpoint,
-		HttpMethod method,
-		JsonSerializerOptions options,
-		string? jwt,
-		object? body = null
+		HttpRequestInit init,
+		JsonSerializerOptions options
 	)
 	{
-		HttpRequestMessage requestMessage = new(method, endpoint);
-
-		if (body is not null)
-		{
-			StringContent content = new(JsonSerializer.Serialize(body, options));
-			content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-			requestMessage.Content = content;
-		}
-
-		if (jwt is not null)
-		{
-			requestMessage.Headers.Authorization = new AuthenticationHeaderValue(JwtBearerDefaults.AuthenticationScheme, jwt);
-		}
-
-		return requestMessage; // To be then called with HttpClient.SendAsync(requestMessage);
-	}
-
-	// TODO: Try to have HttpClient be called within this class. Annoying for callers to keep passing it in.
-	private static async Task<Res> Send<Res>(HttpRequestMessage message, HttpClient client, JsonSerializerOptions options)
-	{
-		HttpResponseMessage response = await client.SendAsync(message);
+		HttpResponseMessage response = await client.SendAsync(
+			CreateRequestMessage(
+				endpoint,
+				init,
+				options
+			)
+		);
 		response.EnsureSuccessStatusCode();
 		return await HttpHelpers.ReadFromResponseBody<Res>(response, options);
 	}
+
+	private static HttpRequestMessage CreateRequestMessage(
+		string endpoint,
+		HttpRequestInit init,
+		JsonSerializerOptions options
+	) =>
+		new(init.Method, endpoint)
+		{
+			Headers =
+			{
+				Authorization = new AuthenticationHeaderValue(JwtBearerDefaults.AuthenticationScheme, init.Jwt)
+			},
+			Content = init.Body switch
+			{
+				not null => new StringContent(JsonSerializer.Serialize(init.Body, options))
+				{
+					Headers =
+					{
+						ContentType = new("application/json"),
+					},
+				},
+				_ => default
+			}
+		};
 }

--- a/LeaderboardBackend.Test/Lib/HttpRequestInit.cs
+++ b/LeaderboardBackend.Test/Lib/HttpRequestInit.cs
@@ -1,0 +1,10 @@
+using System.Net.Http;
+
+namespace LeaderboardBackend.Test.Lib;
+
+internal record HttpRequestInit
+{
+	public object? Body { get; init; }
+	public string? Jwt { get; init; }
+	public HttpMethod Method { get; init; } = HttpMethod.Get;
+}

--- a/LeaderboardBackend.Test/Lib/TestApiFactory.cs
+++ b/LeaderboardBackend.Test/Lib/TestApiFactory.cs
@@ -12,6 +12,7 @@ internal class TestApiFactory : WebApplicationFactory<Program>
 {
 	private static User s_admin = new()
 	{
+		Id = System.Guid.NewGuid(),
 		Username = "AyyLmaoGaming",
 		Email = "ayylmaogaming@alg.gg",
 		Password = "P4ssword",

--- a/LeaderboardBackend.Test/Lib/TestApiFactory.cs
+++ b/LeaderboardBackend.Test/Lib/TestApiFactory.cs
@@ -10,16 +10,7 @@ namespace LeaderboardBackend.Test.Lib;
 
 internal class TestApiFactory : WebApplicationFactory<Program>
 {
-	private static User s_admin = new()
-	{
-		Id = System.Guid.NewGuid(),
-		Username = "AyyLmaoGaming",
-		Email = "ayylmaogaming@alg.gg",
-		Password = "P4ssword",
-		Admin = true,
-	};
-
-	public User GetAdmin() => s_admin;
+	public User GetAdmin() => TestInitCommonFields.Admin;
 
 	protected override void ConfigureWebHost(IWebHostBuilder builder)
 	{
@@ -57,10 +48,10 @@ internal class TestApiFactory : WebApplicationFactory<Program>
 
 		User admin = new()
 		{
-			Id = s_admin.Id,
-			Username = s_admin.Username,
-			Email = s_admin.Email,
-			Password = BCryptNet.EnhancedHashPassword(s_admin.Password),
+			Id = TestInitCommonFields.Admin.Id,
+			Username = TestInitCommonFields.Admin.Username,
+			Email = TestInitCommonFields.Admin.Email,
+			Password = BCryptNet.EnhancedHashPassword(TestInitCommonFields.Admin.Password),
 			Admin = true,
 		};
 

--- a/LeaderboardBackend.Test/Lib/TestApiFactory.cs
+++ b/LeaderboardBackend.Test/Lib/TestApiFactory.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using System.Collections.Generic;
 
 namespace LeaderboardBackend.Test.Lib;
 

--- a/LeaderboardBackend.Test/Lib/TestApiFactory.cs
+++ b/LeaderboardBackend.Test/Lib/TestApiFactory.cs
@@ -17,6 +17,8 @@ internal class TestApiFactory : WebApplicationFactory<Program>
 	private static User Admin = null!;
 	private static readonly string AdminPassword = "P4ssword";
 
+	// TODO: Make this a singleton instead of creating a new object all the time
+	// TODO: Also maybe only save the generated ID
 	public User GetAdmin() => new()
 	{
 		Id = Admin.Id,
@@ -68,17 +70,8 @@ internal class TestApiFactory : WebApplicationFactory<Program>
 			Admin = true,
 		};
 
-		Modship modship = new()
-		{
-			Leaderboard = leaderboard,
-			LeaderboardId = leaderboard.Id,
-			User = Admin,
-			UserId = Admin.Id,
-		};
-
 		dbContext.Add<User>(Admin);
 		dbContext.Add<Leaderboard>(leaderboard);
-		dbContext.Add<Modship>(modship);
 
 		dbContext.SaveChanges();
 	}

--- a/LeaderboardBackend.Test/Lib/TestApiFactory.cs
+++ b/LeaderboardBackend.Test/Lib/TestApiFactory.cs
@@ -10,22 +10,15 @@ namespace LeaderboardBackend.Test.Lib;
 
 internal class TestApiFactory : WebApplicationFactory<Program>
 {
-	// Value needs to be set in `Seed()`, as the constructor doesn't actually get called
-	// in ConfigureWebhost.
-	// Seems like a smell, I know.
-	private static User Admin = null!;
-	private static readonly string AdminPassword = "P4ssword";
-
-	// TODO: Make this a singleton instead of creating a new object all the time
-	// TODO: Also maybe only save the generated ID
-	public User GetAdmin() => new()
+	private static User s_admin = new()
 	{
-		Id = Admin.Id,
 		Username = "AyyLmaoGaming",
 		Email = "ayylmaogaming@alg.gg",
-		Password = AdminPassword,
+		Password = "P4ssword",
 		Admin = true,
 	};
+
+	public User GetAdmin() => s_admin;
 
 	protected override void ConfigureWebHost(IWebHostBuilder builder)
 	{
@@ -61,15 +54,16 @@ internal class TestApiFactory : WebApplicationFactory<Program>
 			Slug = "mario-goes-to-jail"
 		};
 
-		Admin = new()
+		User admin = new()
 		{
-			Username = "AyyLmaoGaming",
-			Email = "ayylmaogaming@alg.gg",
-			Password = BCryptNet.EnhancedHashPassword(AdminPassword),
+			Id = s_admin.Id,
+			Username = s_admin.Username,
+			Email = s_admin.Email,
+			Password = BCryptNet.EnhancedHashPassword(s_admin.Password),
 			Admin = true,
 		};
 
-		dbContext.Add<User>(Admin);
+		dbContext.Add<User>(admin);
 		dbContext.Add<Leaderboard>(leaderboard);
 
 		dbContext.SaveChanges();

--- a/LeaderboardBackend.Test/Lib/TestInitCommonFields.cs
+++ b/LeaderboardBackend.Test/Lib/TestInitCommonFields.cs
@@ -1,0 +1,22 @@
+using LeaderboardBackend.Models.Entities;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace LeaderboardBackend.Test.Lib;
+
+internal record TestInitCommonFields {
+	public static JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions
+	{
+		ReferenceHandler = ReferenceHandler.IgnoreCycles,
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+	};
+
+	public static User Admin = new()
+	{
+		Id = System.Guid.NewGuid(),
+		Username = "AyyLmaoGaming",
+		Email = "ayylmaogaming@alg.gg",
+		Password = "P4ssword",
+		Admin = true,
+	};
+}

--- a/LeaderboardBackend.Test/Lib/UserHelpers.cs
+++ b/LeaderboardBackend.Test/Lib/UserHelpers.cs
@@ -1,0 +1,35 @@
+using LeaderboardBackend.Authorization;
+using LeaderboardBackend.Models.Entities;
+using LeaderboardBackend.Models.Requests.Users;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace LeaderboardBackend.Test.Lib;
+
+internal static class UserHelpers
+{
+	public static async Task<User> Register(HttpClient apiClient, UserTypes userType, JsonSerializerOptions jsonSerializerOptions)
+	{
+		RegisterRequest registerBody = new()
+		{
+			Username = "AyylmaoGaming",
+			Password = "c00l_pAssword",
+			PasswordConfirm = "c00l_pAssword",
+			Email = "test@email.com",
+		};
+
+		return await HttpHelpers.Post<RegisterRequest, User>("/api/users/register", registerBody, apiClient, jsonSerializerOptions);
+	}
+
+	public static async Task<LoginResponse> Login(HttpClient apiClient, User user, JsonSerializerOptions jsonSerializerOptions)
+	{
+		LoginRequest loginBody = new()
+		{
+			Email = user.Email,
+			Password = "c00l_pAssword",
+		};
+
+		return await HttpHelpers.Post<LoginRequest, LoginResponse>("/api/users/login", loginBody, apiClient, jsonSerializerOptions);
+	}
+}

--- a/LeaderboardBackend.Test/Lib/UserHelpers.cs
+++ b/LeaderboardBackend.Test/Lib/UserHelpers.cs
@@ -1,4 +1,3 @@
-using LeaderboardBackend.Authorization;
 using LeaderboardBackend.Models.Entities;
 using LeaderboardBackend.Models.Requests.Users;
 using System.Net.Http;

--- a/LeaderboardBackend.Test/Lib/UserHelpers.cs
+++ b/LeaderboardBackend.Test/Lib/UserHelpers.cs
@@ -1,6 +1,7 @@
 using LeaderboardBackend.Models.Entities;
 using LeaderboardBackend.Models.Requests.Users;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -8,7 +9,13 @@ namespace LeaderboardBackend.Test.Lib;
 
 internal static class UserHelpers
 {
-	public static async Task<User> Register(HttpClient apiClient, string username, string email, string password, JsonSerializerOptions jsonSerializerOptions)
+	public static async Task<User> Register(
+		HttpClient apiClient,
+		string username,
+		string email,
+		string password,
+		JsonSerializerOptions options
+	)
 	{
 		RegisterRequest registerBody = new()
 		{
@@ -18,10 +25,19 @@ internal static class UserHelpers
 			Email = email,
 		};
 
-		return await HttpHelpers.Post<RegisterRequest, User>("/api/users/register", registerBody, apiClient, jsonSerializerOptions);
+		return await HttpHelpers.Send<User>(
+			apiClient,
+			"/api/users/register",
+			new()
+			{
+				Method = HttpMethod.Post,
+				Body = registerBody
+			},
+			options
+		);
 	}
 
-	public static async Task<LoginResponse> Login(HttpClient apiClient, string email, string password, JsonSerializerOptions jsonSerializerOptions)
+	public static async Task<LoginResponse> Login(HttpClient apiClient, string email, string password, JsonSerializerOptions options)
 	{
 		LoginRequest loginBody = new()
 		{
@@ -29,6 +45,15 @@ internal static class UserHelpers
 			Password = password,
 		};
 
-		return await HttpHelpers.Post<LoginRequest, LoginResponse>("/api/users/login", loginBody, apiClient, jsonSerializerOptions);
+		return await HttpHelpers.Send<LoginResponse>(
+			apiClient,
+			"/api/users/login",
+			new()
+			{
+				Method = HttpMethod.Post,
+				Body = loginBody
+			},
+			options
+		);
 	}
 }

--- a/LeaderboardBackend.Test/Lib/UserHelpers.cs
+++ b/LeaderboardBackend.Test/Lib/UserHelpers.cs
@@ -15,45 +15,40 @@ internal static class UserHelpers
 		string email,
 		string password,
 		JsonSerializerOptions options
-	)
-	{
-		RegisterRequest registerBody = new()
-		{
-			Username = username,
-			Password = password,
-			PasswordConfirm = password,
-			Email = email,
-		};
-
-		return await HttpHelpers.Send<User>(
+	) =>
+		await HttpHelpers.Post<User>(
 			apiClient,
 			"/api/users/register",
 			new()
 			{
-				Method = HttpMethod.Post,
-				Body = registerBody
+				Body = new RegisterRequest()
+				{
+					Username = username,
+					Password = password,
+					PasswordConfirm = password,
+					Email = email,
+				}
 			},
 			options
 		);
-	}
 
-	public static async Task<LoginResponse> Login(HttpClient apiClient, string email, string password, JsonSerializerOptions options)
-	{
-		LoginRequest loginBody = new()
-		{
-			Email = email,
-			Password = password,
-		};
-
-		return await HttpHelpers.Send<LoginResponse>(
+	public static async Task<LoginResponse> Login(
+		HttpClient apiClient,
+		string email,
+		string password,
+		JsonSerializerOptions options
+	) =>
+		await HttpHelpers.Post<LoginResponse>(
 			apiClient,
 			"/api/users/login",
 			new()
 			{
-				Method = HttpMethod.Post,
-				Body = loginBody
+				Body = new LoginRequest()
+				{
+					Email = email,
+					Password = password,
+				}
 			},
 			options
 		);
-	}
 }

--- a/LeaderboardBackend.Test/Lib/UserHelpers.cs
+++ b/LeaderboardBackend.Test/Lib/UserHelpers.cs
@@ -9,25 +9,25 @@ namespace LeaderboardBackend.Test.Lib;
 
 internal static class UserHelpers
 {
-	public static async Task<User> Register(HttpClient apiClient, UserTypes userType, JsonSerializerOptions jsonSerializerOptions)
+	public static async Task<User> Register(HttpClient apiClient, string username, string email, string password, JsonSerializerOptions jsonSerializerOptions)
 	{
 		RegisterRequest registerBody = new()
 		{
-			Username = "AyylmaoGaming",
-			Password = "c00l_pAssword",
-			PasswordConfirm = "c00l_pAssword",
-			Email = "test@email.com",
+			Username = username,
+			Password = password,
+			PasswordConfirm = password,
+			Email = email,
 		};
 
 		return await HttpHelpers.Post<RegisterRequest, User>("/api/users/register", registerBody, apiClient, jsonSerializerOptions);
 	}
 
-	public static async Task<LoginResponse> Login(HttpClient apiClient, User user, JsonSerializerOptions jsonSerializerOptions)
+	public static async Task<LoginResponse> Login(HttpClient apiClient, string email, string password, JsonSerializerOptions jsonSerializerOptions)
 	{
 		LoginRequest loginBody = new()
 		{
-			Email = user.Email,
-			Password = "c00l_pAssword",
+			Email = email,
+			Password = password,
 		};
 
 		return await HttpHelpers.Post<LoginRequest, LoginResponse>("/api/users/login", loginBody, apiClient, jsonSerializerOptions);

--- a/LeaderboardBackend.Test/Lib/UserHelpers.cs
+++ b/LeaderboardBackend.Test/Lib/UserHelpers.cs
@@ -1,7 +1,6 @@
 using LeaderboardBackend.Models.Entities;
 using LeaderboardBackend.Models.Requests.Users;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -13,8 +12,7 @@ internal static class UserHelpers
 		HttpClient apiClient,
 		string username,
 		string email,
-		string password,
-		JsonSerializerOptions options
+		string password
 	) =>
 		await HttpHelpers.Post<User>(
 			apiClient,
@@ -28,15 +26,13 @@ internal static class UserHelpers
 					PasswordConfirm = password,
 					Email = email,
 				}
-			},
-			options
+			}
 		);
 
 	public static async Task<LoginResponse> Login(
 		HttpClient apiClient,
 		string email,
-		string password,
-		JsonSerializerOptions options
+		string password
 	) =>
 		await HttpHelpers.Post<LoginResponse>(
 			apiClient,
@@ -48,7 +44,22 @@ internal static class UserHelpers
 					Email = email,
 					Password = password,
 				}
-			},
-			options
+			}
+		);
+
+	public static async Task<LoginResponse> LoginAdmin(
+		HttpClient apiClient
+	) =>
+		await HttpHelpers.Post<LoginResponse>(
+			apiClient,
+			"/api/users/login",
+			new()
+			{
+				Body = new LoginRequest()
+				{
+					Email = TestInitCommonFields.Admin.Email,
+					Password = TestInitCommonFields.Admin.Password,
+				}
+			}
 		);
 }

--- a/LeaderboardBackend.Test/Modships.cs
+++ b/LeaderboardBackend.Test/Modships.cs
@@ -4,9 +4,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using LeaderboardBackend.Models.Requests.Leaderboards;
 using LeaderboardBackend.Models.Requests.Modships;
-using LeaderboardBackend.Models.Requests.Users;
 using LeaderboardBackend.Models.Entities;
-using System.Net.Http.Json;
 using LeaderboardBackend.Test.Lib;
 
 namespace LeaderboardBackend.Test;
@@ -35,8 +33,6 @@ internal class Modships
 	[Test]
 	public static async Task MakeMod_Success()
 	{
-		// Note: Retrieved Modship doesn't retrieve relations. I.e. it's User (but not User ID) field is null
-		// Also GET modship endpoint doesn't return arrays, although it should.
 		User admin = Factory.GetAdmin();
 		string jwt = await Login(admin);
 		Leaderboard createdLeaderboard = await CreateLeaderboard(jwt);
@@ -48,19 +44,25 @@ internal class Modships
 			UserId = admin.Id,
 		};
 
-		Modship created = await HttpHelpers.Post<CreateModshipRequest, Modship>(
-			"/api/modships",
-			makeModBody,
+		Modship created = await HttpHelpers.Post<Modship>(
 			ApiClient,
-			JsonSerializerOptions,
-			jwt
+			"/api/modships",
+			new()
+			{
+				Body = makeModBody,
+				Jwt = jwt
+			},
+			JsonSerializerOptions
 		);
 
 		Modship retrieved = await HttpHelpers.Get<Modship>(
-			$"/api/modships/{admin.Id}",
 			ApiClient,
-			JsonSerializerOptions,
-			jwt
+			$"/api/modships/{admin.Id}",
+			new()
+			{
+				Jwt = jwt
+			},
+			JsonSerializerOptions
 		);
 
 		Assert.NotNull(created.User);
@@ -69,18 +71,19 @@ internal class Modships
 
 	private static async Task<Leaderboard> CreateLeaderboard(string jwt)
 	{
-		CreateLeaderboardRequest createLeaderboardBody = new()
-		{
-			Name = "Mario Goes to Jail II",
-			Slug = "mario-goes-to-jail-ii"
-		};
-
-		return await HttpHelpers.Post<CreateLeaderboardRequest, Leaderboard>(
-			"/api/leaderboards",
-			createLeaderboardBody,
+		return await HttpHelpers.Post<Leaderboard>(
 			ApiClient,
-			JsonSerializerOptions,
-			jwt
+			"/api/leaderboards",
+			new()
+			{
+				Body = new CreateLeaderboardRequest()
+				{
+					Name = "Mario Goes to Jail II",
+					Slug = "mario-goes-to-jail-ii"
+				},
+				Jwt = jwt
+			},
+			JsonSerializerOptions
 		);
 	}
 

--- a/LeaderboardBackend.Test/Modships.cs
+++ b/LeaderboardBackend.Test/Modships.cs
@@ -30,7 +30,7 @@ internal class Modships
 	public static async Task MakeMod_Success()
 	{
 		User admin = Factory.GetAdmin();
-		string jwt = await Login(admin);
+		string jwt = (await UserHelpers.Login(ApiClient, admin.Email, admin.Password)).Token;
 		Leaderboard createdLeaderboard = await CreateLeaderboard(jwt);
 
 		// Make user a mod
@@ -47,8 +47,7 @@ internal class Modships
 			{
 				Body = makeModBody,
 				Jwt = jwt
-			},
-			JsonSerializerOptions
+			}
 		);
 
 		Modship retrieved = await HttpHelpers.Get<Modship>(
@@ -57,8 +56,7 @@ internal class Modships
 			new()
 			{
 				Jwt = jwt
-			},
-			JsonSerializerOptions
+			}
 		);
 
 		Assert.NotNull(created.User);
@@ -78,11 +76,7 @@ internal class Modships
 					Slug = "mario-goes-to-jail-ii"
 				},
 				Jwt = jwt
-			},
-			JsonSerializerOptions
+			}
 		);
 	}
-
-	private static async Task<string> Login(User user) =>
-		(await UserHelpers.Login(ApiClient, user.Email, user.Password, JsonSerializerOptions)).Token;
 }

--- a/LeaderboardBackend.Test/Modships.cs
+++ b/LeaderboardBackend.Test/Modships.cs
@@ -19,10 +19,6 @@ internal class Modships
 		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
 	};
 
-	private static readonly string ValidUsername = "Test";
-	private static readonly string ValidPassword = "c00l_pAssword";
-	private static readonly string ValidEmail = "test@email.com";
-
 	[SetUp]
 	public static void SetUp()
 	{

--- a/LeaderboardBackend.Test/Users.cs
+++ b/LeaderboardBackend.Test/Users.cs
@@ -45,20 +45,20 @@ internal class Users
 	[Test]
 	public static async Task GetUser_Found()
 	{
-		RegisterRequest registerBody = new()
-		{
-			Username = ValidUsername,
-			Password = ValidPassword,
-			PasswordConfirm = ValidPassword,
-			Email = ValidEmail,
-		};
-		HttpResponseMessage registerResponse = await ApiClient.PostAsJsonAsync("/api/users/register", registerBody, JsonSerializerOptions);
-		registerResponse.EnsureSuccessStatusCode();
-		User createdUser = await HttpHelpers.ReadFromResponseBody<User>(registerResponse, JsonSerializerOptions);
+		User createdUser = await UserHelpers.Register(
+			ApiClient,
+			ValidUsername,
+			ValidEmail,
+			ValidPassword,
+			JsonSerializerOptions
+		);
 
-		HttpResponseMessage userResponse = await ApiClient.GetAsync($"/api/users/{createdUser?.Id}");
-		userResponse.EnsureSuccessStatusCode();
-		User retrievedUser = await HttpHelpers.ReadFromResponseBody<User>(userResponse, JsonSerializerOptions);
+		User retrievedUser = await HttpHelpers.Get<User>(
+			ApiClient,
+			$"/api/users/{createdUser?.Id}",
+			new(),
+			JsonSerializerOptions
+		);
 
 		Assert.AreEqual(createdUser, retrievedUser);
 	}
@@ -91,7 +91,7 @@ internal class Users
 			},
 		};
 
-		foreach(RegisterRequest request in requests)
+		foreach (RegisterRequest request in requests)
 		{
 			HttpResponseMessage registerResponse = await ApiClient.PostAsJsonAsync("/api/users/register", request, JsonSerializerOptions);
 			Assert.AreEqual(

--- a/LeaderboardBackend.Test/Users.cs
+++ b/LeaderboardBackend.Test/Users.cs
@@ -18,10 +18,6 @@ internal class Users
 {
 	private static TestApiFactory Factory = null!;
 	private static HttpClient ApiClient = null!;
-	private static JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions
-	{
-		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-	};
 
 	private static readonly string ValidUsername = "Test";
 	private static readonly string ValidPassword = "c00l_pAssword";
@@ -49,15 +45,13 @@ internal class Users
 			ApiClient,
 			ValidUsername,
 			ValidEmail,
-			ValidPassword,
-			JsonSerializerOptions
+			ValidPassword
 		);
 
 		User retrievedUser = await HttpHelpers.Get<User>(
 			ApiClient,
 			$"/api/users/{createdUser?.Id}",
-			new(),
-			JsonSerializerOptions
+			new()
 		);
 
 		Assert.AreEqual(createdUser, retrievedUser);
@@ -93,7 +87,7 @@ internal class Users
 
 		foreach (RegisterRequest request in requests)
 		{
-			HttpResponseMessage registerResponse = await ApiClient.PostAsJsonAsync("/api/users/register", request, JsonSerializerOptions);
+			HttpResponseMessage registerResponse = await ApiClient.PostAsJsonAsync("/api/users/register", request);
 			Assert.AreEqual(
 				HttpStatusCode.BadRequest,
 				registerResponse.StatusCode,
@@ -121,9 +115,9 @@ internal class Users
 			PasswordConfirm = ValidPassword,
 			Email = ValidEmail,
 		};
-		HttpResponseMessage registerResponse = await ApiClient.PostAsJsonAsync("/api/users/register", registerBody, JsonSerializerOptions);
+		HttpResponseMessage registerResponse = await ApiClient.PostAsJsonAsync("/api/users/register", registerBody);
 		registerResponse.EnsureSuccessStatusCode();
-		User createdUser = await HttpHelpers.ReadFromResponseBody<User>(registerResponse, JsonSerializerOptions);
+		User createdUser = await HttpHelpers.ReadFromResponseBody<User>(registerResponse);
 
 		// Login
 		LoginRequest loginBody = new()
@@ -131,10 +125,10 @@ internal class Users
 			Email = createdUser.Email,
 			Password = ValidPassword,
 		};
-		HttpResponseMessage loginResponse = await ApiClient.PostAsJsonAsync("/api/users/login", loginBody, JsonSerializerOptions);
+		HttpResponseMessage loginResponse = await ApiClient.PostAsJsonAsync("/api/users/login", loginBody);
 		loginResponse.EnsureSuccessStatusCode();
 
-		string token = (await HttpHelpers.ReadFromResponseBody<LoginResponse>(loginResponse, JsonSerializerOptions)).Token;
+		string token = (await HttpHelpers.ReadFromResponseBody<LoginResponse>(loginResponse)).Token;
 
 		// Me
 		HttpRequestMessage meRequest = new(
@@ -148,7 +142,7 @@ internal class Users
 		};
 		HttpResponseMessage meResponse = await ApiClient.SendAsync(meRequest);
 		meResponse.EnsureSuccessStatusCode();
-		User meUser = await HttpHelpers.ReadFromResponseBody<User>(registerResponse, JsonSerializerOptions);
+		User meUser = await HttpHelpers.ReadFromResponseBody<User>(registerResponse);
 		Assert.AreEqual(createdUser, meUser);
 	}
 }

--- a/LeaderboardBackend.Test/Users.cs
+++ b/LeaderboardBackend.Test/Users.cs
@@ -31,7 +31,7 @@ internal class Users
 	public static void SetUp()
 	{
 		Factory = new TestApiFactory();
-		ApiClient = Factory.CreateClient();	
+		ApiClient = Factory.CreateClient();
 	}
 
 	[Test]
@@ -45,7 +45,7 @@ internal class Users
 	[Test]
 	public static async Task GetUser_Found()
 	{
-		RegisterRequest registerBody = new() 
+		RegisterRequest registerBody = new()
 		{
 			Username = ValidUsername,
 			Password = ValidPassword,
@@ -95,8 +95,8 @@ internal class Users
 		{
 			HttpResponseMessage registerResponse = await ApiClient.PostAsJsonAsync("/api/users/register", request, JsonSerializerOptions);
 			Assert.AreEqual(
-				HttpStatusCode.BadRequest, 
-				registerResponse.StatusCode, 
+				HttpStatusCode.BadRequest,
+				registerResponse.StatusCode,
 				$"{request} did not produce BadRequest, produced {registerResponse.StatusCode}"
 			);
 		}
@@ -114,7 +114,7 @@ internal class Users
 	public static async Task FullAuthFlow()
 	{
 		// Register User
-		RegisterRequest registerBody = new() 
+		RegisterRequest registerBody = new()
 		{
 			Username = ValidUsername,
 			Password = ValidPassword,
@@ -125,7 +125,7 @@ internal class Users
 		registerResponse.EnsureSuccessStatusCode();
 		User createdUser = await HttpHelpers.ReadFromResponseBody<User>(registerResponse, JsonSerializerOptions);
 
-		// Login		
+		// Login
 		LoginRequest loginBody = new()
 		{
 			Email = createdUser!.Email,
@@ -147,7 +147,7 @@ internal class Users
 			}
 		};
 		HttpResponseMessage meResponse = await ApiClient.SendAsync(meRequest);
-		meResponse.EnsureSuccessStatusCode();	
+		meResponse.EnsureSuccessStatusCode();
 		User meUser = await HttpHelpers.ReadFromResponseBody<User>(registerResponse, JsonSerializerOptions);
 		Assert.AreEqual(createdUser, meUser);
 	}

--- a/LeaderboardBackend.Test/Users.cs
+++ b/LeaderboardBackend.Test/Users.cs
@@ -128,7 +128,7 @@ internal class Users
 		// Login
 		LoginRequest loginBody = new()
 		{
-			Email = createdUser!.Email,
+			Email = createdUser.Email,
 			Password = ValidPassword,
 		};
 		HttpResponseMessage loginResponse = await ApiClient.PostAsJsonAsync("/api/users/login", loginBody, JsonSerializerOptions);

--- a/LeaderboardBackend/Authorization/JwtSecurityTokenHandlerSingleton.cs
+++ b/LeaderboardBackend/Authorization/JwtSecurityTokenHandlerSingleton.cs
@@ -1,0 +1,15 @@
+using System.IdentityModel.Tokens.Jwt;
+
+namespace LeaderboardBackend.Authorization;
+
+/// <summary>
+/// Class that holds a JwtSecurityTokenHandler instance.
+/// </summary>
+/// <remarks>
+/// Singleton definition style taken from https://csharpindepth.com/Articles/Singleton.
+/// </remarks>
+public sealed class JwtSecurityTokenHandlerSingleton
+{
+	public static readonly JwtSecurityTokenHandler Instance = new();
+	private JwtSecurityTokenHandlerSingleton() {}
+}

--- a/LeaderboardBackend/Authorization/JwtSecurityTokenHandlerSingleton.cs
+++ b/LeaderboardBackend/Authorization/JwtSecurityTokenHandlerSingleton.cs
@@ -8,8 +8,7 @@ namespace LeaderboardBackend.Authorization;
 /// <remarks>
 /// Singleton definition style taken from https://csharpindepth.com/Articles/Singleton.
 /// </remarks>
-public sealed class JwtSecurityTokenHandlerSingleton
+public static class JwtSecurityTokenHandlerSingleton
 {
 	public static readonly JwtSecurityTokenHandler Instance = new();
-	private JwtSecurityTokenHandlerSingleton() {}
 }

--- a/LeaderboardBackend/Authorization/MiddlewareResultHandler.cs
+++ b/LeaderboardBackend/Authorization/MiddlewareResultHandler.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Policy;
+// using Microsoft.AspNetCore.Http;
+// using System.Linq;
+using System.Net;
+// using System.Threading.Tasks;
+
+namespace LeaderboardBackend.Authorization;
+
+public class MiddlewareResultHandler : IAuthorizationMiddlewareResultHandler
+{
+   private readonly AuthorizationMiddlewareResultHandler
+        DefaultHandler = new AuthorizationMiddlewareResultHandler();
+
+    public async Task HandleAsync(
+        RequestDelegate requestDelegate,
+        HttpContext httpContext,
+        AuthorizationPolicy authorizationPolicy,
+        PolicyAuthorizationResult policyAuthorizationResult)
+    {
+        // if the authorization was forbidden and the resource had specific requirements,
+        // provide a custom response.
+        if (Show404ForForbiddenResult(policyAuthorizationResult))
+        {
+            // Return a 404 to make it appear as if the resource does not exist.
+            httpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
+            return;
+        }
+
+        // Fallback to the default implementation.
+		// This can mean calling the controller action itself.
+        await DefaultHandler.HandleAsync(requestDelegate, httpContext, authorizationPolicy,
+                               policyAuthorizationResult);
+    }
+
+    bool Show404ForForbiddenResult(PolicyAuthorizationResult policyAuthorizationResult)
+    {
+        return policyAuthorizationResult.Forbidden &&
+            policyAuthorizationResult.AuthorizationFailure.FailedRequirements.OfType<
+                                                           Show404Requirement>().Any();
+    }
+}
+
+public class Show404Requirement : IAuthorizationRequirement { }

--- a/LeaderboardBackend/Authorization/MiddlewareResultHandler.cs
+++ b/LeaderboardBackend/Authorization/MiddlewareResultHandler.cs
@@ -1,9 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authorization.Policy;
-// using Microsoft.AspNetCore.Http;
-// using System.Linq;
 using System.Net;
-// using System.Threading.Tasks;
 
 namespace LeaderboardBackend.Authorization;
 
@@ -18,11 +15,8 @@ public class MiddlewareResultHandler : IAuthorizationMiddlewareResultHandler
         AuthorizationPolicy authorizationPolicy,
         PolicyAuthorizationResult policyAuthorizationResult)
     {
-        // if the authorization was forbidden and the resource had specific requirements,
-        // provide a custom response.
         if (Show404ForForbiddenResult(policyAuthorizationResult))
         {
-            // Return a 404 to make it appear as if the resource does not exist.
             httpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
             return;
         }
@@ -35,10 +29,6 @@ public class MiddlewareResultHandler : IAuthorizationMiddlewareResultHandler
 
     bool Show404ForForbiddenResult(PolicyAuthorizationResult policyAuthorizationResult)
     {
-        return policyAuthorizationResult.Forbidden &&
-            policyAuthorizationResult.AuthorizationFailure.FailedRequirements.OfType<
-                                                           Show404Requirement>().Any();
+        return policyAuthorizationResult.Forbidden;
     }
 }
-
-public class Show404Requirement : IAuthorizationRequirement { }

--- a/LeaderboardBackend/Authorization/MiddlewareResultHandler.cs
+++ b/LeaderboardBackend/Authorization/MiddlewareResultHandler.cs
@@ -15,7 +15,7 @@ public class MiddlewareResultHandler : IAuthorizationMiddlewareResultHandler
         AuthorizationPolicy authorizationPolicy,
         PolicyAuthorizationResult policyAuthorizationResult)
     {
-        if (Show404ForForbiddenResult(policyAuthorizationResult))
+        if (policyAuthorizationResult.Forbidden)
         {
             httpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
             return;
@@ -25,10 +25,5 @@ public class MiddlewareResultHandler : IAuthorizationMiddlewareResultHandler
 		// This can mean calling the controller action itself.
         await DefaultHandler.HandleAsync(requestDelegate, httpContext, authorizationPolicy,
                                policyAuthorizationResult);
-    }
-
-    bool Show404ForForbiddenResult(PolicyAuthorizationResult policyAuthorizationResult)
-    {
-        return policyAuthorizationResult.Forbidden;
     }
 }

--- a/LeaderboardBackend/Authorization/Requirements/UserTypeRequirement.cs
+++ b/LeaderboardBackend/Authorization/Requirements/UserTypeRequirement.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace LeaderboardBackend.Authorization.Requirements;
+
+public record UserTypeRequirement : IAuthorizationRequirement
+{
+	public UserTypeRequirement(string type) =>
+		Type = type;
+	public string Type { get; }
+}

--- a/LeaderboardBackend/Authorization/TokenValidationParametersSingleton.cs
+++ b/LeaderboardBackend/Authorization/TokenValidationParametersSingleton.cs
@@ -1,0 +1,25 @@
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
+
+namespace LeaderboardBackend.Authorization;
+
+public sealed class TokenValidationParametersSingleton
+{
+	private static TokenValidationParameters? parameters = null;
+
+	public static TokenValidationParameters Instance(IConfiguration configuration)
+	{
+		if (parameters is not null)
+		{
+			return parameters;
+		}
+		SymmetricSecurityKey key = new(Encoding.UTF8.GetBytes(configuration["Jwt:Key"]));
+		parameters = new()
+		{
+			IssuerSigningKey = key,
+			ValidAudience = configuration["Jwt:Issuer"],
+			ValidIssuer = configuration["Jwt:Issuer"]
+		};
+		return parameters;
+	}
+}

--- a/LeaderboardBackend/Authorization/UserTypeAuthorizationHandler.cs
+++ b/LeaderboardBackend/Authorization/UserTypeAuthorizationHandler.cs
@@ -22,15 +22,7 @@ public class UserTypeAuthorizationHandler : AuthorizationHandler<UserTypeRequire
 	{
 		_config = config;
 		_jwtHandler = JwtSecurityTokenHandlerSingleton.Instance;
-
-		// FIXME: Make _jwtValidationParams take from a singleton too
-		SymmetricSecurityKey key = new(Encoding.UTF8.GetBytes(config["Jwt:Key"]));
-		_jwtValidationParams = new()
-		{
-			IssuerSigningKey = key,
-			ValidAudience = config["Jwt:Issuer"],
-			ValidIssuer = config["Jwt:Issuer"]
-		};
+		_jwtValidationParams = TokenValidationParametersSingleton.Instance(config);
 		_userService = userService;
 	}
 

--- a/LeaderboardBackend/Authorization/UserTypeAuthorizationHandler.cs
+++ b/LeaderboardBackend/Authorization/UserTypeAuthorizationHandler.cs
@@ -1,4 +1,3 @@
-using LeaderboardBackend.Authorization.Requirements;
 using LeaderboardBackend.Models;
 using LeaderboardBackend.Services;
 using Microsoft.AspNetCore.Authorization;

--- a/LeaderboardBackend/Authorization/UserTypeAuthorizationHandler.cs
+++ b/LeaderboardBackend/Authorization/UserTypeAuthorizationHandler.cs
@@ -1,0 +1,109 @@
+using LeaderboardBackend.Authorization.Requirements;
+using LeaderboardBackend.Models;
+using LeaderboardBackend.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Text;
+
+namespace LeaderboardBackend.Authorization;
+
+public class UserTypeAuthorizationHandler : AuthorizationHandler<UserTypeRequirement>
+{
+	private readonly IConfiguration _config;
+	private readonly JwtSecurityTokenHandler _jwtHandler;
+	private readonly TokenValidationParameters _jwtValidationParams;
+	private readonly IUserService _userService;
+
+	public UserTypeAuthorizationHandler(
+		IConfiguration config,
+		IModshipService modshipService,
+		IUserService userService
+	)
+	{
+		_config = config;
+		_jwtHandler = JwtSecurityTokenHandlerSingleton.Instance;
+
+		// FIXME: Make _jwtValidationParams take from a singleton too
+		SymmetricSecurityKey key = new(Encoding.UTF8.GetBytes(config["Jwt:Key"]));
+		_jwtValidationParams = new()
+		{
+			IssuerSigningKey = key,
+			ValidAudience = config["Jwt:Issuer"],
+			ValidIssuer = config["Jwt:Issuer"]
+		};
+		_userService = userService;
+	}
+
+	protected override Task HandleRequirementAsync(
+		AuthorizationHandlerContext context,
+		UserTypeRequirement requirement
+	)
+	{
+		if (!CanGetJwt(context, out string token) || !CanValidateJwt(token))
+		{
+			return Task.CompletedTask;
+		}
+
+		User? user = _userService.GetUserFromClaims(context.User).Result;
+
+		if (user is null || !Handle(user, context, requirement))
+		{
+			// FIXME: Work out how to fail as a ForbiddenResult.
+			context.Fail();
+			return Task.CompletedTask;
+		}
+
+		context.Succeed(requirement);
+
+		return Task.CompletedTask;
+	}
+
+	private bool Handle(
+		User user,
+		AuthorizationHandlerContext context,
+		UserTypeRequirement requirement
+	) => requirement.Type switch
+	{
+		UserTypes.Admin => IsAdmin(user),
+		UserTypes.Mod => IsMod(user),
+		UserTypes.User => true,
+		_ => false,
+	};
+
+	// FIXME: Rebase PR which adds Admin prop to Users
+	private bool IsAdmin(User user) => false;
+
+	// FIXME: Users don't get automagically populated with Modships when on creation of the latter.
+	private bool IsMod(User user) => user.Modships?.Count() > 0;
+
+	private bool CanGetJwt(AuthorizationHandlerContext context, out string token)
+	{
+		if (context.Resource is not HttpContext httpContext)
+		{
+			token = "";
+			return false;
+		}
+		// We need to strip "Bearer " out lol
+		token = httpContext.Request.Headers.Authorization.First().Substring(7);
+		return _jwtHandler.CanReadToken(token);
+	}
+
+	private bool CanValidateJwt(string token)
+	{
+		try
+		{
+			_jwtHandler.ValidateToken(
+				token,
+				_jwtValidationParams,
+				out _
+			);
+			return true;
+		}
+		// FIXME: Trigger a redirect to login, possibly on SecurityTokenExpiredException
+		catch (System.Exception)
+		{
+			return false;
+		}
+	}
+}

--- a/LeaderboardBackend/Authorization/UserTypeAuthorizationHandler.cs
+++ b/LeaderboardBackend/Authorization/UserTypeAuthorizationHandler.cs
@@ -1,9 +1,8 @@
-using LeaderboardBackend.Models;
+using LeaderboardBackend.Models.Entities;
 using LeaderboardBackend.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
-using System.Text;
 
 namespace LeaderboardBackend.Authorization;
 
@@ -62,8 +61,7 @@ public class UserTypeAuthorizationHandler : AuthorizationHandler<UserTypeRequire
 		_ => false,
 	};
 
-	// FIXME: Rebase PR which adds Admin prop to Users
-	private bool IsAdmin(User user) => false;
+	private bool IsAdmin(User user) => user.Admin;
 
 	// FIXME: Users don't get automagically populated with Modships when on creation of the latter.
 	private bool IsMod(User user) => user.Modships?.Count() > 0;
@@ -75,9 +73,17 @@ public class UserTypeAuthorizationHandler : AuthorizationHandler<UserTypeRequire
 			token = "";
 			return false;
 		}
-		// We need to strip "Bearer " out lol
-		token = httpContext.Request.Headers.Authorization.First().Substring(7);
-		return _jwtHandler.CanReadToken(token);
+		try
+		{
+			// We need to strip "Bearer " out lol
+			token = httpContext.Request.Headers.Authorization.First().Substring(7);
+			return _jwtHandler.CanReadToken(token);
+		} catch (System.InvalidOperationException)
+		{
+			// No token exists in the request
+			token = "";
+			return false;
+		}
 	}
 
 	private bool CanValidateJwt(string token)

--- a/LeaderboardBackend/Authorization/UserTypeRequirement.cs
+++ b/LeaderboardBackend/Authorization/UserTypeRequirement.cs
@@ -1,6 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 
-namespace LeaderboardBackend.Authorization.Requirements;
+namespace LeaderboardBackend.Authorization;
 
 public record UserTypeRequirement : IAuthorizationRequirement
 {

--- a/LeaderboardBackend/Authorization/UserTypes.cs
+++ b/LeaderboardBackend/Authorization/UserTypes.cs
@@ -1,0 +1,8 @@
+namespace LeaderboardBackend.Authorization;
+
+public readonly record struct UserTypes
+{
+	public const string Admin = "Admin";
+	public const string Mod = "Mod";
+	public const string User = "User";
+}

--- a/LeaderboardBackend/Controllers/LeaderboardsController.cs
+++ b/LeaderboardBackend/Controllers/LeaderboardsController.cs
@@ -1,3 +1,4 @@
+using LeaderboardBackend.Authorization;
 using LeaderboardBackend.Models.Entities;
 using LeaderboardBackend.Models.Requests.Leaderboards;
 using LeaderboardBackend.Controllers.Annotations;
@@ -56,6 +57,7 @@ public class LeaderboardsController : ControllerBase
 	/// <response code="404">If a non-admin calls this.</response>
 	[ApiConventionMethod(typeof(Conventions),
 						 nameof(Conventions.Post))]
+	[Authorize(Policy = UserTypes.Admin)]
 	[HttpPost]
 	public async Task<ActionResult<Leaderboard>> CreateLeaderboard([FromBody] CreateLeaderboardRequest body)
 	{

--- a/LeaderboardBackend/Controllers/LeaderboardsController.cs
+++ b/LeaderboardBackend/Controllers/LeaderboardsController.cs
@@ -2,6 +2,7 @@ using LeaderboardBackend.Models.Entities;
 using LeaderboardBackend.Models.Requests.Leaderboards;
 using LeaderboardBackend.Controllers.Annotations;
 using LeaderboardBackend.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LeaderboardBackend.Controllers;
@@ -23,6 +24,7 @@ public class LeaderboardsController : ControllerBase
 	/// <response code="404">If no Leaderboard can be found.</response>
 	[ApiConventionMethod(typeof(Conventions),
 						 nameof(Conventions.Get))]
+	[AllowAnonymous]
 	[HttpGet("{id}")]
 	public async Task<ActionResult<Leaderboard>> GetLeaderboard(long id)
 	{
@@ -39,6 +41,7 @@ public class LeaderboardsController : ControllerBase
 	/// <param name="ids">The IDs.</param>
 	/// <response code="200">An array of Leaderboards. Can be empty.</response>
 	[ProducesResponseType(StatusCodes.Status200OK)]
+	[AllowAnonymous]
 	[HttpGet]
 	public async Task<ActionResult<List<Leaderboard>>> GetLeaderboards([FromQuery] long[] ids)
 	{

--- a/LeaderboardBackend/Controllers/LeaderboardsController.cs
+++ b/LeaderboardBackend/Controllers/LeaderboardsController.cs
@@ -49,7 +49,6 @@ public class LeaderboardsController : ControllerBase
 		return Ok(await _leaderboardService.GetLeaderboards(ids));
 	}
 
-	// FIXME: Only allow admins to call this route
 	/// <summary>Creates a new Leaderboard. Admin-only.</summary>
 	/// <param name="body">A CreateLeaderboardRequest instance.</param>
 	/// <response code="201">The created Leaderboard.</response>

--- a/LeaderboardBackend/Controllers/ModshipsController.cs
+++ b/LeaderboardBackend/Controllers/ModshipsController.cs
@@ -1,7 +1,9 @@
+using LeaderboardBackend.Authorization;
 using LeaderboardBackend.Models.Entities;
 using LeaderboardBackend.Models.Requests.Modships;
 using LeaderboardBackend.Services;
 using LeaderboardBackend.Controllers.Annotations;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LeaderboardBackend.Controllers;
@@ -44,7 +46,6 @@ public class ModshipsController : ControllerBase
 		return Ok(modship);
 	}
 
-	// FIXME: Add authz for admins only
 	/// <summary>Makes a User a Mod for a Leaderboard. Admin-only.</summary>
 	/// <param name="body">A CreateModshipRequest instance.</param>
 	/// <response code="201">An object containing the Modship ID.</response>
@@ -52,6 +53,7 @@ public class ModshipsController : ControllerBase
 	/// <response code="404">If a non-admin calls this.</response>
 	[ApiConventionMethod(typeof(Conventions),
 						 nameof(Conventions.Post))]
+	[Authorize(Policy = UserTypes.Admin)]
 	[HttpPost]
 	public async Task<ActionResult> MakeMod([FromBody] CreateModshipRequest body)
 	{

--- a/LeaderboardBackend/Controllers/UsersController.cs
+++ b/LeaderboardBackend/Controllers/UsersController.cs
@@ -38,6 +38,7 @@ public class UsersController : ControllerBase
 		}
 
 		// FIXME: Return DTO that excludes email
+		user.Email = "";
 		return Ok(user);
 	}
 

--- a/LeaderboardBackend/Controllers/UsersController.cs
+++ b/LeaderboardBackend/Controllers/UsersController.cs
@@ -27,6 +27,7 @@ public class UsersController : ControllerBase
 	/// <response code="404">If no User is found with the provided ID.</response>
 	[ApiConventionMethod(typeof(Conventions),
 						 nameof(Conventions.Get))]
+	[AllowAnonymous]
 	[HttpGet("{id:guid}")]
 	public async Task<ActionResult<User>> GetUserById(Guid id)
 	{

--- a/LeaderboardBackend/Controllers/UsersController.cs
+++ b/LeaderboardBackend/Controllers/UsersController.cs
@@ -121,7 +121,6 @@ public class UsersController : ControllerBase
 	/// <response code="403">If an invalid JWT was passed in.</response>
 	[ProducesResponseType(StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status403Forbidden)]
-	[Authorize]
 	[HttpGet("me")]
 	public async Task<ActionResult<User>> Me()
 	{

--- a/LeaderboardBackend/Models/Entities/Modship.cs
+++ b/LeaderboardBackend/Models/Entities/Modship.cs
@@ -12,14 +12,12 @@ public class Modship
 	[Required]
 	public Guid UserId { get; set; }
 
-	[JsonIgnore]
 	public User? User { get; set; } = null!;
 
 	/// <summary>ID of the Leaderboard the User is a mod for.</summary>
 	[Required]
 	public long LeaderboardId { get; set; }
 
-	[JsonIgnore]
 	public Leaderboard? Leaderboard { get; set; } = null!;
 
 	public override bool Equals(object? obj)

--- a/LeaderboardBackend/Models/Entities/User.cs
+++ b/LeaderboardBackend/Models/Entities/User.cs
@@ -30,6 +30,7 @@ public class User
 	/// <summary>The User's email. Must be, well, an email.</summary>
 	/// <example>ayylmao.gaming@alg.gg</example>
 	[Required]
+	[JsonIgnore]
 	public string Email { get; set; } = null!;
 
 	[Required]
@@ -43,15 +44,12 @@ public class User
 	[Required]
 	public bool Admin { get; set; } = false;
 
-	[JsonIgnore]
 	[InverseProperty("BanningUser")]
 	public List<Ban>? BansGiven { get; set; }
 
-	[JsonIgnore]
 	[InverseProperty("BannedUser")]
 	public List<Ban>? BansReceived { get; set; }
 
-	[JsonIgnore]
 	public List<Modship>? Modships { get; set; }
 
 	public override bool Equals(object? obj)

--- a/LeaderboardBackend/Models/Entities/User.cs
+++ b/LeaderboardBackend/Models/Entities/User.cs
@@ -54,9 +54,7 @@ public class User
 	public override bool Equals(object? obj)
 	{
 		return obj is User user &&
-			   Id.Equals(user.Id) &&
-			   Username.ToLower() == user.Username.ToLower() &&
-			   Email == user.Email;
+			   Id.Equals(user.Id);
 	}
 
 	public override int GetHashCode()

--- a/LeaderboardBackend/Models/Entities/User.cs
+++ b/LeaderboardBackend/Models/Entities/User.cs
@@ -30,7 +30,6 @@ public class User
 	/// <summary>The User's email. Must be, well, an email.</summary>
 	/// <example>ayylmao.gaming@alg.gg</example>
 	[Required]
-	[JsonIgnore]
 	public string Email { get; set; } = null!;
 
 	[Required]

--- a/LeaderboardBackend/Program.cs
+++ b/LeaderboardBackend/Program.cs
@@ -107,6 +107,7 @@ builder.Services.AddAuthorization(options =>
 
 // Can't use AddSingleton here since we call the DB in the Handler
 builder.Services.AddScoped<IAuthorizationHandler, UserTypeAuthorizationHandler>();
+builder.Services.AddSingleton<IAuthorizationMiddlewareResultHandler, MiddlewareResultHandler>();
 
 #endregion
 

--- a/LeaderboardBackend/Program.cs
+++ b/LeaderboardBackend/Program.cs
@@ -3,6 +3,7 @@ using dotenv.net.Utilities;
 using LeaderboardBackend.Models.Entities;
 using LeaderboardBackend.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
@@ -72,6 +73,14 @@ builder.Services
 			IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]))
 		};
 	});
+
+// Configure authorisation.
+builder.Services.AddAuthorization(options =>
+{
+	options.FallbackPolicy = new AuthorizationPolicyBuilder()
+		.RequireAuthenticatedUser()
+		.Build();
+});
 
 #endregion
 

--- a/LeaderboardBackend/Program.cs
+++ b/LeaderboardBackend/Program.cs
@@ -2,7 +2,6 @@ using dotenv.net;
 using dotenv.net.Utilities;
 using LeaderboardBackend.Models.Entities;
 using LeaderboardBackend.Authorization;
-using LeaderboardBackend.Authorization.Requirements;
 using LeaderboardBackend.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;

--- a/LeaderboardBackend/Program.cs
+++ b/LeaderboardBackend/Program.cs
@@ -12,6 +12,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 #region WebApplicationBuilder
 
@@ -43,6 +44,7 @@ builder.Services.AddControllers(opt =>
 	opt.OutputFormatters.RemoveType<StringOutputFormatter>();
 }).AddJsonOptions(opt =>
 {
+	opt.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
 	opt.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
 });
 

--- a/LeaderboardBackend/Services/IModshipService.cs
+++ b/LeaderboardBackend/Services/IModshipService.cs
@@ -6,6 +6,7 @@ public interface IModshipService
 {
 	Task<Modship?> GetModship(Guid userId);
 	Task CreateModship(Modship modship);
+	Task<List<Modship>> LoadUserModships(Guid userId);
 	// TODO: Implement this
 	// Task DeleteModship(Modship modship);
 }

--- a/LeaderboardBackend/Services/Impl/ModshipService.cs
+++ b/LeaderboardBackend/Services/Impl/ModshipService.cs
@@ -23,6 +23,13 @@ public class ModshipService : IModshipService
 		await _applicationContext.SaveChangesAsync();
 	}
 
+	public async Task<List<Modship>> LoadUserModships(Guid userId)
+	{
+		return await _applicationContext.Modships
+					.Where(m => m.UserId == userId)
+					.ToListAsync();
+	}
+
 	// TODO: Implement this
 	// public async Task DeleteModship(Modship modship)
 	// {

--- a/LeaderboardBackend/Services/Impl/ModshipService.cs
+++ b/LeaderboardBackend/Services/Impl/ModshipService.cs
@@ -14,7 +14,7 @@ public class ModshipService : IModshipService
 
 	public async Task<Modship?> GetModship(Guid userId)
 	{
-		return await _applicationContext.Modships.SingleOrDefaultAsync(m => m.UserId == userId);
+		return await _applicationContext.Modships.FirstOrDefaultAsync(m => m.UserId == userId);
 	}
 
 	public async Task CreateModship(Modship modship)

--- a/LeaderboardBackend/Services/Impl/UserService.cs
+++ b/LeaderboardBackend/Services/Impl/UserService.cs
@@ -16,22 +16,7 @@ public class UserService : IUserService
 
 	public async Task<User?> GetUserById(Guid id)
 	{
-		User? user = await _applicationContext.Users.FindAsync(id);
-		if (user is null)
-		{
-			return null;
-		}
-
-		try
-		{
-			user.Modships = await _applicationContext.Modships
-			.Where(m => m.UserId == user.Id)
-			.ToListAsync();
-			return user;
-		} catch (ArgumentNullException)
-		{
-			return user;
-		}
+		return await _applicationContext.Users.FindAsync(id);
 	}
 
 	public async Task<User?> GetUserByEmail(string email)

--- a/LeaderboardBackend/Services/Impl/UserService.cs
+++ b/LeaderboardBackend/Services/Impl/UserService.cs
@@ -28,7 +28,7 @@ public class UserService : IUserService
 	{
 		// We save a username with casing, but match without.
 		// Effectively you can't have two separate users named e.g. "cool" and "cOoL".
-		return await _applicationContext.Users.SingleOrDefaultAsync(u => u.Username != null && u.Username.ToLower() == name.ToLower());
+		return await _applicationContext.Users.FirstOrDefaultAsync(u => u.Username != null && u.Username.ToLower() == name.ToLower());
 	}
 
 	public async Task<User?> GetUserFromClaims(ClaimsPrincipal claims)

--- a/LeaderboardBackend/Services/Impl/UserService.cs
+++ b/LeaderboardBackend/Services/Impl/UserService.cs
@@ -16,7 +16,22 @@ public class UserService : IUserService
 
 	public async Task<User?> GetUserById(Guid id)
 	{
-		return await _applicationContext.Users.FindAsync(id);
+		User? user = await _applicationContext.Users.FindAsync(id);
+		if (user is null)
+		{
+			return null;
+		}
+
+		try
+		{
+			user.Modships = await _applicationContext.Modships
+			.Where(m => m.UserId == user.Id)
+			.ToListAsync();
+			return user;
+		} catch (ArgumentNullException)
+		{
+			return user;
+		}
 	}
 
 	public async Task<User?> GetUserByEmail(string email)

--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ The value provided to `--urls` has to match what's listed under `applicationUrl`
 
 To run the tests, run the following commands from the root of the project:
 
-```
+```bash
 cd LeaderboardBackend.Test
 dotnet test
 ```
+
+To debug with breakpoints, first call `export VSTEST_DEBUG=1` before running a test. Doing this allows you to attach a debug process to hit breakpoints with.


### PR DESCRIPTION
Closes: #52.

Implements authorisation in the app based on our three current user types: admins, mods, and users. All controller actions now default to requiring authenticated users unless explicitly given the `[AllowAnonymous]` attribute. Also, actions requiring specific authZ will have an `[Authorize(Policy = <UserType>)]` attribute. These are handled by the `UserTypeAuthorizationHandler` class.

Todo:
- [x] Tests tests tests
- [x] Figure out how to trigger Forbiddens when authZ handler fails
- [x] Make `_jwtValidationParams` take from a singleton
- [x] Rebase this onto PR/main that has `Admin` property on Users
- [x] Get User-Modship relationship working