### PR TITLE
Create JudgementsController

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,8 +68,7 @@ Bug: {short description}
 
 ### C#
 
-- Add tests for any new feature or bug fix, to ensure things continue to work.
-- Early returns are great, they help reduce nesting!
+- Please refer to the [style guide](https://github.com/leaderboardsgg/leaderboard-backend/wiki/Style-Guide).
 
 ### Git
 

--- a/LeaderboardBackend.Test/Judgements.cs
+++ b/LeaderboardBackend.Test/Judgements.cs
@@ -3,7 +3,7 @@ using LeaderboardBackend.Models.Requests;
 using LeaderboardBackend.Test.Lib;
 using LeaderboardBackend.Test.TestApi;
 using LeaderboardBackend.Test.TestApi.Extensions;
-using LeaderboardBackend.ViewModels;
+using LeaderboardBackend.Models.ViewModels;
 using NUnit.Framework;
 using System;
 using System.Threading.Tasks;

--- a/LeaderboardBackend.Test/Judgements.cs
+++ b/LeaderboardBackend.Test/Judgements.cs
@@ -93,8 +93,8 @@ internal class Judgements
 			{
 				Body = new CreateRunRequest
 				{
-					Played = DateTime.Now,
-					Submitted = DateTime.Now,
+					Played = DateTime.UtcNow,
+					Submitted = DateTime.UtcNow,
 					Status = RunStatus.SUBMITTED,
 				},
 				Jwt = Jwt,

--- a/LeaderboardBackend.Test/Judgements.cs
+++ b/LeaderboardBackend.Test/Judgements.cs
@@ -1,0 +1,104 @@
+using LeaderboardBackend.Models.Entities;
+using LeaderboardBackend.Models.Requests;
+using LeaderboardBackend.Test.Lib;
+using LeaderboardBackend.Test.TestApi;
+using LeaderboardBackend.Test.TestApi.Extensions;
+using LeaderboardBackend.ViewModels;
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+
+namespace LeaderboardBackend.Test;
+
+[TestFixture]
+internal class Judgements
+{
+	private static TestApiFactory Factory = null!;
+	private static TestApiClient ApiClient = null!;
+	private static Leaderboard DefaultLeaderboard = null!;
+	private static string? Jwt;
+
+	private static readonly string ValidUsername = "Test";
+	private static readonly string ValidPassword = "c00l_pAssword";
+	private static readonly string ValidEmail = "test@email.com";
+
+	[SetUp]
+	public static async Task SetUp()
+	{
+		Factory = new TestApiFactory();
+		ApiClient = Factory.CreateTestApiClient();
+
+		// Set up a default Leaderboard and a mod user for that leaderboard to use as the Jwt for tests
+		string adminJwt = (await ApiClient.LoginAdminUser()).Token;
+		User mod = await ApiClient.RegisterUser(
+			ValidUsername,
+			ValidEmail,
+			ValidPassword
+		);
+		DefaultLeaderboard = await ApiClient.Post<Leaderboard>(
+			"/api/leaderboards",
+			new()
+			{
+				Body = new CreateLeaderboardRequest
+				{
+					Name = Generators.GenerateRandomString(),
+					Slug = Generators.GenerateRandomString(),
+				},
+				Jwt = adminJwt,
+			}
+		);
+		Modship modship = await ApiClient.Post<Modship>(
+			"/api/modships",
+			new()
+			{
+				Body = new CreateModshipRequest
+				{
+					LeaderboardId = DefaultLeaderboard.Id,
+					UserId = mod.Id,
+				},
+				Jwt = adminJwt,
+			}
+		);
+
+		Jwt = (await ApiClient.LoginUser(ValidEmail, ValidPassword)).Token;
+	}
+
+	[Test]
+	public async Task CreateJudgement_OK()
+	{
+		Run run = await CreateRun();
+
+		JudgementViewModel? createdJudgement = await ApiClient.Post<JudgementViewModel>(
+			"/api/judgements",
+			new()
+			{
+				Body = new CreateJudgementRequest
+				{
+					RunId = run.Id,
+					Note = "It is a cool run",
+					Approved = true,
+				},
+				Jwt = Jwt,
+			}
+		);
+
+		Assert.NotNull(createdJudgement);
+	}
+
+	private async Task<Run> CreateRun()
+	{
+		return await ApiClient.Post<Run>(
+			"/api/runs",
+			new()
+			{
+				Body = new CreateRunRequest
+				{
+					Played = DateTime.Now,
+					Submitted = DateTime.Now,
+					Status = RunStatus.SUBMITTED,
+				},
+				Jwt = Jwt,
+			}
+		);
+	}
+}

--- a/LeaderboardBackend.Test/TestApi/TestApiClient.cs
+++ b/LeaderboardBackend.Test/TestApi/TestApiClient.cs
@@ -20,7 +20,7 @@ internal sealed class RequestFailureException : Exception
 {
 	public HttpResponseMessage Response { get; private set; }
 
-	public RequestFailureException(HttpResponseMessage response) : base("The attempted request failed")
+	public RequestFailureException(HttpResponseMessage response) : base($"The attempted request failed with status code {response.StatusCode}")
 	{
 		Response = response;
 	}

--- a/LeaderboardBackend/Authorization/UserTypeAuthorizationHandler.cs
+++ b/LeaderboardBackend/Authorization/UserTypeAuthorizationHandler.cs
@@ -58,7 +58,7 @@ public class UserTypeAuthorizationHandler : AuthorizationHandler<UserTypeRequire
 	) => requirement.Type switch
 	{
 		UserTypes.Admin => user.Admin,
-		UserTypes.Mod => IsMod(user),
+		UserTypes.Mod => user.Admin || IsMod(user),
 		UserTypes.User => true,
 		_ => false,
 	};

--- a/LeaderboardBackend/Authorization/UserTypeAuthorizationHandler.cs
+++ b/LeaderboardBackend/Authorization/UserTypeAuthorizationHandler.cs
@@ -61,7 +61,7 @@ public class UserTypeAuthorizationHandler : AuthorizationHandler<UserTypeRequire
 		_ => false,
 	};
 
-	//private bool IsAdmin(User user) => user.Admin;
+	private bool IsAdmin(User user) => user.Admin;
 
 	// FIXME: Users don't get automagically populated with Modships when on creation of the latter.
 	private bool IsMod(User user) => user.Modships?.Count() > 0;

--- a/LeaderboardBackend/Authorization/UserTypeAuthorizationHandler.cs
+++ b/LeaderboardBackend/Authorization/UserTypeAuthorizationHandler.cs
@@ -12,6 +12,7 @@ public class UserTypeAuthorizationHandler : AuthorizationHandler<UserTypeRequire
 	private readonly JwtSecurityTokenHandler _jwtHandler;
 	private readonly TokenValidationParameters _jwtValidationParams;
 	private readonly IUserService _userService;
+	private readonly IModshipService _modshipService;
 
 	public UserTypeAuthorizationHandler(
 		IConfiguration config,
@@ -23,6 +24,7 @@ public class UserTypeAuthorizationHandler : AuthorizationHandler<UserTypeRequire
 		_jwtHandler = JwtSecurityTokenHandlerSingleton.Instance;
 		_jwtValidationParams = TokenValidationParametersSingleton.Instance(config);
 		_userService = userService;
+		_modshipService = modshipService;
 	}
 
 	protected override Task HandleRequirementAsync(
@@ -61,10 +63,7 @@ public class UserTypeAuthorizationHandler : AuthorizationHandler<UserTypeRequire
 		_ => false,
 	};
 
-	private bool IsAdmin(User user) => user.Admin;
-
-	// FIXME: Users don't get automagically populated with Modships when on creation of the latter.
-	private bool IsMod(User user) => user.Modships?.Count() > 0;
+	private bool IsMod(User user) => _modshipService.LoadUserModships(user.Id).Result.Count() > 0;
 
 	private bool TryGetJwtFromHttpContext(AuthorizationHandlerContext context, out string token)
 	{

--- a/LeaderboardBackend/Controllers/JudgementsController.cs
+++ b/LeaderboardBackend/Controllers/JudgementsController.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Mvc;
+using LeaderboardBackend.Controllers.Annotations;
+using LeaderboardBackend.Models.Entities;
+using LeaderboardBackend.Models.Requests;
+using LeaderboardBackend.Services;
+
+namespace LeaderboardBackend.Controllers;
+
+public class JudgementsController : ControllerBase
+{
+	private readonly IJudgementService _judgementService;
+
+	public JudgementsController(
+		IJudgementService judgementService
+	)
+	{
+		_judgementService = judgementService;
+	}
+
+	/// <summary>Gets a Judgement from its ID.</summary>
+	/// <response code="200">The Judgement with the provided ID.</response>
+	/// <response code="404">If no Judgement can be found.</response>
+	[ApiConventionMethod(typeof(Conventions),
+						 nameof(Conventions.Get))]
+	[HttpGet("{id}")]
+	public async Task<ActionResult<Judgement>> GetJudgement(long id)
+	{
+		Judgement? judgement = await _judgementService.GetJudgement(id);
+		if (judgement is null)
+		{
+			return NotFound();
+		}
+
+		return Ok(judgement);
+	}
+
+	public async Task<ActionResult<Judgement>> CreateJudgement([FromBody] CreateJudgementRequest body) {
+		//
+	}
+}

--- a/LeaderboardBackend/Controllers/JudgementsController.cs
+++ b/LeaderboardBackend/Controllers/JudgementsController.cs
@@ -3,7 +3,7 @@ using LeaderboardBackend.Controllers.Annotations;
 using LeaderboardBackend.Models.Entities;
 using LeaderboardBackend.Models.Requests;
 using LeaderboardBackend.Services;
-using LeaderboardBackend.ViewModels;
+using LeaderboardBackend.Models.ViewModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 

--- a/LeaderboardBackend/Controllers/JudgementsController.cs
+++ b/LeaderboardBackend/Controllers/JudgementsController.cs
@@ -5,7 +5,6 @@ using LeaderboardBackend.Models.Requests;
 using LeaderboardBackend.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using System.Linq;
 
 namespace LeaderboardBackend.Controllers;
 
@@ -64,8 +63,7 @@ public class JudgementsController : ControllerBase
 		{
 			// This shouldn't happen, as authZ should block already.
 			_logger.LogError($"CreateJudgement: retrieved mod is null. Run ID = {body.RunId}");
-			// FIXME: Return a 500 here instead. Dunno what the right function's called rn.
-			return NotFound();
+			return new StatusCodeResult(StatusCodes.Status500InternalServerError);
 		}
 
 		if (run is null)
@@ -86,6 +84,7 @@ public class JudgementsController : ControllerBase
 
 		await _judgementService.CreateJudgement(judgement);
 
+		// TODO: We need to return a DTO here that omits returning Mod and Run.
 		return CreatedAtAction(nameof(GetJudgement), new { id = judgement.Id }, judgement);
 	}
 }

--- a/LeaderboardBackend/Controllers/JudgementsController.cs
+++ b/LeaderboardBackend/Controllers/JudgementsController.cs
@@ -54,9 +54,9 @@ public class JudgementsController : ControllerBase
 	/// <response code="400">The request body is malformed.</response>
 	/// <response code="403">The run has pending participations.</response>
 	/// <response code="404">For an invalid judgement.</response>
+	[ProducesResponseType(StatusCodes.Status403Forbidden)]
 	[ApiConventionMethod(typeof(Conventions),
 						nameof(Conventions.Post))]
-	[ProducesResponseType(StatusCodes.Status403Forbidden)]
 	[Authorize(Policy = UserTypes.Mod)]
 	[HttpPost]
 	public async Task<ActionResult<JudgementViewModel>> CreateJudgement([FromBody] CreateJudgementRequest body)

--- a/LeaderboardBackend/Controllers/JudgementsController.cs
+++ b/LeaderboardBackend/Controllers/JudgementsController.cs
@@ -72,6 +72,12 @@ public class JudgementsController : ControllerBase
 			return NotFound($"Run not found for ID = {body.RunId}");
 		}
 
+		if (run.Status == RunStatus.CREATED)
+		{
+			_logger.LogError($"CreateJudgement: run has status CREATED. ID = {body.RunId}");
+			return NotFound($"Run has pending Participations. ID = {body.RunId}");
+		}
+
 		Judgement judgement = new()
 		{
 			Approved = body.Approved,

--- a/LeaderboardBackend/Controllers/JudgementsController.cs
+++ b/LeaderboardBackend/Controllers/JudgementsController.cs
@@ -89,6 +89,8 @@ public class JudgementsController : ControllerBase
 
 		await _judgementService.CreateJudgement(judgement);
 
-		return CreatedAtAction(nameof(GetJudgement), new JudgementViewModel(judgement));
+		JudgementViewModel judgementView = new(judgement);
+
+		return CreatedAtAction(nameof(GetJudgement), new { id = judgementView.Id }, judgementView);
 	}
 }

--- a/LeaderboardBackend/Controllers/JudgementsController.cs
+++ b/LeaderboardBackend/Controllers/JudgementsController.cs
@@ -1,20 +1,32 @@
-using Microsoft.AspNetCore.Mvc;
+using LeaderboardBackend.Authorization;
 using LeaderboardBackend.Controllers.Annotations;
 using LeaderboardBackend.Models.Entities;
 using LeaderboardBackend.Models.Requests;
 using LeaderboardBackend.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
 
 namespace LeaderboardBackend.Controllers;
 
 public class JudgementsController : ControllerBase
 {
+	private readonly ILogger _logger;
 	private readonly IJudgementService _judgementService;
+	private readonly IRunService _runService;
+	private readonly IUserService _userService;
 
 	public JudgementsController(
-		IJudgementService judgementService
+		ILogger<JudgementsController> logger,
+		IJudgementService judgementService,
+		IRunService runService,
+		IUserService userService
 	)
 	{
+		_logger = logger;
 		_judgementService = judgementService;
+		_runService = runService;
+		_userService = userService;
 	}
 
 	/// <summary>Gets a Judgement from its ID.</summary>
@@ -34,7 +46,46 @@ public class JudgementsController : ControllerBase
 		return Ok(judgement);
 	}
 
+	/// <summary>Creates a judgement for a run.</summary>
+	/// <response code="201">The created judgement.</response>
+	/// <response code="400">The request body is malformed.</response>
+	/// <response code="404">For an invalid judgement.</response>
+	/// <response code="500">If the client's User model cannot be retrieved for some reason.</response>
+	[ApiConventionMethod(typeof(Conventions),
+						nameof(Conventions.Post))]
+	[ProducesResponseType(StatusCodes.Status500InternalServerError)]
+	[Authorize(Policy = UserTypes.Mod)]
+	[HttpPost("{id}")]
 	public async Task<ActionResult<Judgement>> CreateJudgement([FromBody] CreateJudgementRequest body) {
-		//
+		User? mod = await _userService.GetUserFromClaims(HttpContext.User);
+		Run? run = await _runService.GetRun(body.RunId);
+
+		if (mod is null)
+		{
+			// This shouldn't happen, as authZ should block already.
+			_logger.LogError($"CreateJudgement: retrieved mod is null. Run ID = {body.RunId}");
+			// FIXME: Return a 500 here instead. Dunno what the right function's called rn.
+			return NotFound();
+		}
+
+		if (run is null)
+		{
+			_logger.LogError($"CreateJudgement: run is null. ID = {body.RunId}");
+			return NotFound($"Run not found for ID = {body.RunId}");
+		}
+
+		Judgement judgement = new()
+		{
+			Approved = body.Approved,
+			Mod = mod,
+			ModId = mod.Id,
+			Note = body.Note,
+			Run = run,
+			RunId = run.Id,
+		};
+
+		await _judgementService.CreateJudgement(judgement);
+
+		return CreatedAtAction(nameof(GetJudgement), new { id = judgement.Id }, judgement);
 	}
 }

--- a/LeaderboardBackend/Controllers/JudgementsController.cs
+++ b/LeaderboardBackend/Controllers/JudgementsController.cs
@@ -11,6 +11,7 @@ namespace LeaderboardBackend.Controllers;
 
 [Route("api/[controller]")]
 [ApiController]
+[Produces("application/json")]
 public class JudgementsController : ControllerBase
 {
 	private readonly ILogger _logger;
@@ -52,9 +53,7 @@ public class JudgementsController : ControllerBase
 	/// <summary>Creates a judgement for a run.</summary>
 	/// <response code="201">The created judgement.</response>
 	/// <response code="400">The request body is malformed.</response>
-	/// <response code="403">The run has pending participations.</response>
 	/// <response code="404">For an invalid judgement.</response>
-	[ProducesResponseType(StatusCodes.Status403Forbidden)]
 	[ApiConventionMethod(typeof(Conventions),
 						nameof(Conventions.Post))]
 	[Authorize(Policy = UserTypes.Mod)]
@@ -73,7 +72,7 @@ public class JudgementsController : ControllerBase
 		if (run.Status == RunStatus.CREATED)
 		{
 			_logger.LogError($"CreateJudgement: run has pending participations (i.e. run status == CREATED). ID = {body.RunId}");
-			return Forbid($"Run has pending Participations. ID = {body.RunId}");
+			return BadRequest($"Run has pending Participations. ID = {body.RunId}");
 		}
 
 		// TODO: Update run status on body.Approved's value

--- a/LeaderboardBackend/Migrations/20220508171859_Judgements_ChangeApproverFieldsToModFields.Designer.cs
+++ b/LeaderboardBackend/Migrations/20220508171859_Judgements_ChangeApproverFieldsToModFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LeaderboardBackend.Models.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LeaderboardBackend.Migrations
 {
     [DbContext(typeof(ApplicationContext))]
-    partial class ApplicationContextModelSnapshot : ModelSnapshot
+    [Migration("20220508171859_Judgements_ChangeApproverFieldsToModFields")]
+    partial class Judgements_ChangeApproverFieldsToModFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -124,12 +126,6 @@ namespace LeaderboardBackend.Migrations
                         .HasColumnType("boolean")
                         .HasColumnName("approved");
 
-                    b.Property<DateTime>("CreatedAt")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("created_at")
-                        .HasDefaultValueSql("getdate()");
-
                     b.Property<Guid>("ModId")
                         .HasColumnType("uuid")
                         .HasColumnName("mod_id");
@@ -142,6 +138,10 @@ namespace LeaderboardBackend.Migrations
                     b.Property<Guid>("RunId")
                         .HasColumnType("uuid")
                         .HasColumnName("run_id");
+
+                    b.Property<DateTime>("timestamp")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("timestamp");
 
                     b.HasKey("Id")
                         .HasName("pk_judgements");

--- a/LeaderboardBackend/Migrations/20220508171859_Judgements_ChangeApproverFieldsToModFields.cs
+++ b/LeaderboardBackend/Migrations/20220508171859_Judgements_ChangeApproverFieldsToModFields.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LeaderboardBackend.Migrations
+{
+    public partial class Judgements_ChangeApproverFieldsToModFields : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_judgements_users_approver_id",
+                table: "judgements");
+
+            migrationBuilder.RenameColumn(
+                name: "approver_id",
+                table: "judgements",
+                newName: "mod_id");
+
+            migrationBuilder.RenameIndex(
+                name: "ix_judgements_approver_id",
+                table: "judgements",
+                newName: "ix_judgements_mod_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_judgements_users_mod_id",
+                table: "judgements",
+                column: "mod_id",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_judgements_users_mod_id",
+                table: "judgements");
+
+            migrationBuilder.RenameColumn(
+                name: "mod_id",
+                table: "judgements",
+                newName: "approver_id");
+
+            migrationBuilder.RenameIndex(
+                name: "ix_judgements_mod_id",
+                table: "judgements",
+                newName: "ix_judgements_approver_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_judgements_users_approver_id",
+                table: "judgements",
+                column: "approver_id",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/LeaderboardBackend/Migrations/20220508171950_Judgements_ChangeTimestampToCreatedAt.Designer.cs
+++ b/LeaderboardBackend/Migrations/20220508171950_Judgements_ChangeTimestampToCreatedAt.Designer.cs
@@ -130,7 +130,7 @@ namespace LeaderboardBackend.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("created_at")
-                        .HasDefaultValueSql("getdate()");
+                        .HasDefaultValueSql("now()");
 
                     b.Property<Guid>("ModId")
                         .HasColumnType("uuid")

--- a/LeaderboardBackend/Migrations/20220508171950_Judgements_ChangeTimestampToCreatedAt.Designer.cs
+++ b/LeaderboardBackend/Migrations/20220508171950_Judgements_ChangeTimestampToCreatedAt.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LeaderboardBackend.Models.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LeaderboardBackend.Migrations
 {
     [DbContext(typeof(ApplicationContext))]
-    partial class ApplicationContextModelSnapshot : ModelSnapshot
+    [Migration("20220508171950_Judgements_ChangeTimestampToCreatedAt")]
+    partial class Judgements_ChangeTimestampToCreatedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/LeaderboardBackend/Migrations/20220508171950_Judgements_ChangeTimestampToCreatedAt.cs
+++ b/LeaderboardBackend/Migrations/20220508171950_Judgements_ChangeTimestampToCreatedAt.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LeaderboardBackend.Migrations
+{
+    public partial class Judgements_ChangeTimestampToCreatedAt : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "timestamp",
+                table: "judgements");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "created_at",
+                table: "judgements",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "getdate()");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "created_at",
+                table: "judgements");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "timestamp",
+                table: "judgements",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+    }
+}

--- a/LeaderboardBackend/Migrations/20220508171950_Judgements_ChangeTimestampToCreatedAt.cs
+++ b/LeaderboardBackend/Migrations/20220508171950_Judgements_ChangeTimestampToCreatedAt.cs
@@ -18,7 +18,7 @@ namespace LeaderboardBackend.Migrations
                 table: "judgements",
                 type: "timestamp with time zone",
                 nullable: false,
-                defaultValueSql: "getdate()");
+                defaultValueSql: "now()");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/LeaderboardBackend/Migrations/ApplicationContextModelSnapshot.cs
+++ b/LeaderboardBackend/Migrations/ApplicationContextModelSnapshot.cs
@@ -128,7 +128,7 @@ namespace LeaderboardBackend.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("created_at")
-                        .HasDefaultValueSql("getdate()");
+                        .HasDefaultValueSql("now()");
 
                     b.Property<Guid>("ModId")
                         .HasColumnType("uuid")

--- a/LeaderboardBackend/Models/Annotations/NoteAttribute.cs
+++ b/LeaderboardBackend/Models/Annotations/NoteAttribute.cs
@@ -3,10 +3,10 @@ using System.ComponentModel.DataAnnotations;
 
 namespace LeaderboardBackend.Models.Annotations;
 
+/// <summary>Asserts that Note is non-empty for non-approval judgements (Approved is false or null).</summary>
 public class NoteAttribute : ValidationAttribute {
 	protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
 	{
-		// Note defaults to "" in the model itself
 		string note = (string)value!;
 
 		CreateJudgementRequest request = (CreateJudgementRequest)validationContext.ObjectInstance;

--- a/LeaderboardBackend/Models/Annotations/NoteAttribute.cs
+++ b/LeaderboardBackend/Models/Annotations/NoteAttribute.cs
@@ -1,0 +1,21 @@
+using LeaderboardBackend.Models.Requests;
+using System.ComponentModel.DataAnnotations;
+
+namespace LeaderboardBackend.Models.Annotations;
+
+public class NoteAttribute : ValidationAttribute {
+	protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+	{
+		// Note defaults to "" in the model itself
+		string note = (string)value!;
+
+		CreateJudgementRequest request = (CreateJudgementRequest)validationContext.ObjectInstance;
+
+		if (request.Note.Length == 0 && (request.Approved is null || request.Approved is false))
+		{
+			return new ValidationResult("Notes must be provided with this judgement.");
+		}
+
+		return ValidationResult.Success;
+	}
+}

--- a/LeaderboardBackend/Models/Entities/ApplicationContext.cs
+++ b/LeaderboardBackend/Models/Entities/ApplicationContext.cs
@@ -16,7 +16,6 @@ public class ApplicationContext : DbContext
 	public DbSet<Participation> Participations { get; set; } = null!;
 	public DbSet<User> Users { get; set; } = null!;
 
-	// TODO: Verify timestamp's generated to UTC
 	protected override void OnModelCreating(ModelBuilder modelBuilder)
 	{
 		modelBuilder.Entity<Judgement>()

--- a/LeaderboardBackend/Models/Entities/ApplicationContext.cs
+++ b/LeaderboardBackend/Models/Entities/ApplicationContext.cs
@@ -21,6 +21,6 @@ public class ApplicationContext : DbContext
 	{
 		modelBuilder.Entity<Judgement>()
 			.Property(j => j.CreatedAt)
-			.HasDefaultValueSql("getdate()");
+			.HasDefaultValueSql("now()");
 	}
 }

--- a/LeaderboardBackend/Models/Entities/ApplicationContext.cs
+++ b/LeaderboardBackend/Models/Entities/ApplicationContext.cs
@@ -11,8 +11,16 @@ public class ApplicationContext : DbContext
 	public DbSet<Category> Categories { get; set; } = null!;
 	public DbSet<Judgement> Judgements { get; set; } = null!;
 	public DbSet<Leaderboard> Leaderboards { get; set; } = null!;
-	public DbSet<Modship> Modships { get; set; } = null!; 
-	public DbSet<Run> Runs { get; set; } = null!; 
-	public DbSet<Participation> Participations { get; set; } = null!; 
+	public DbSet<Modship> Modships { get; set; } = null!;
+	public DbSet<Run> Runs { get; set; } = null!;
+	public DbSet<Participation> Participations { get; set; } = null!;
 	public DbSet<User> Users { get; set; } = null!;
+
+	// TODO: Verify timestamp's generated to UTC
+	protected override void OnModelCreating(ModelBuilder modelBuilder)
+	{
+		modelBuilder.Entity<Judgement>()
+			.Property(j => j.CreatedAt)
+			.HasDefaultValueSql("getdate()");
+	}
 }

--- a/LeaderboardBackend/Models/Entities/Judgement.cs
+++ b/LeaderboardBackend/Models/Entities/Judgement.cs
@@ -1,29 +1,63 @@
 using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
 
 namespace LeaderboardBackend.Models.Entities;
 
+/// <summary>A decision by a mod on a run submission.</summary>
+/// <remarks>
+/// The latest judgement on a run updates its status.
+/// A judgement can be one of these three types:
+/// <ol>
+///   <li>an approval if <code>Approval == true</code>;</li>
+///   <li>a rejection if <code>Approval == false</code>; and</li>
+///   <li>a comment if <code>Approval == null</code>.</li>
+/// </ol>
+/// Judgements are NOT created if:
+/// <ul>
+///   <li>its related run has "CREATED" status;</li>
+///   <li>its <code>Note</code> is empty while its <code>Approved</code> is <code>false</code> or <code>null</code>.</li>
+/// </ul>
+/// I.e. for the second point, a mod MUST add a note if they want to reject or simply comment on a submission.
+/// Moderators CANNOT modify their judgements once made.
+/// </remarks>
 public class Judgement
 {
+	/// <summary>Generated on creation.</summary>
 	public long Id { get; set; }
 
+	/// <summary>Defines this judgement, which in turn defines the status of its related run.</summary>
+	/// <remarks>
+	/// If:
+	/// <ul>
+	///   <li><code>true</code>, run is approved;</li>
+	///   <li><code>false</code>, run is rejected;</li>
+	///   <li><code>null</code>, run is commented on.</li>
+	/// </ul>
+	/// For the latter two, <code>Note</code> MUST be non-empty.
+	/// </remarks>
 	public bool? Approved { get; set; }
 
+	/// <summary>When the judgement was made.</summary>
 	[Required]
-	public DateTime timestamp { get; set; }
+	public DateTime CreatedAt { get; set; }
 
+	/// <summary>Comments on the judgement.</summary>
+	/// <remarks>MUST be non-empty for rejections or comments (<code>Approved ∈ {false, null}</code>).</remarks>
 	[Required]
-	public string Note { get; set; } = null!;
+	public string Note { get; set; } = "";
 
+	/// <summary>ID of the mod that made this judgement.</summary>
 	[Required]
-	public Guid ApproverId { get; set; }
+	public Guid ModId { get; set; }
 
-	[JsonIgnore]
-	public User? Approver { get; set; }
+	/// <summary>Model of the mod that made this judgement.</summary>
+	[Required]
+	public User Mod { get; set; } = null!;
 
+	/// <summary>ID of the related run.</summary>
 	[Required]
 	public Guid RunId { get; set; }
 
-	[JsonIgnore]
-	public Run? Run { get; set; } = null!;
+	/// <summary>Model of the related run.</summary>
+	[Required]
+	public Run Run { get; set; } = null!;
 }

--- a/LeaderboardBackend/Models/Entities/Judgement.cs
+++ b/LeaderboardBackend/Models/Entities/Judgement.cs
@@ -5,18 +5,14 @@ namespace LeaderboardBackend.Models.Entities;
 /// <summary>A decision by a mod on a run submission.</summary>
 /// <remarks>
 /// The latest judgement on a run updates its status.
-/// A judgement can be one of these three types:
-/// <ol>
-///   <li>an approval if <code>Approval == true</code>;</li>
-///   <li>a rejection if <code>Approval == false</code>; and</li>
-///   <li>a comment if <code>Approval == null</code>.</li>
-/// </ol>
-/// Judgements are NOT created if:
-/// <ul>
-///   <li>its related run has "CREATED" status;</li>
-///   <li>its <code>Note</code> is empty while its <code>Approved</code> is <code>false</code> or <code>null</code>.</li>
-/// </ul>
-/// I.e. for the second point, a mod MUST add a note if they want to reject or simply comment on a submission.
+/// A judgement can be one of these three types: <br/>
+/// - an approval if Approval == true; <br/>
+/// - a rejection if Approval == false; and <br/>
+/// - a comment if Approval == null. <br/>
+/// Judgements are NOT created if: <br/>
+/// - its related run has "CREATED" status; <br/>
+/// - its Note is empty while its Approved is false or null. <br/>
+/// I.e. for the second point, a mod MUST add a note if they want to reject or simply comment on a submission. <br/>
 /// Moderators CANNOT modify their judgements once made.
 /// </remarks>
 public class Judgement
@@ -24,24 +20,26 @@ public class Judgement
 	/// <summary>Generated on creation.</summary>
 	public long Id { get; set; }
 
-	/// <summary>Defines this judgement, which in turn defines the status of its related run.</summary>
-	/// <remarks>
+	/// <summary>
+	/// Defines this judgement, which in turn defines the status of its related run. <br />
 	/// If:
-	/// <ul>
-	///   <li><code>true</code>, run is approved;</li>
-	///   <li><code>false</code>, run is rejected;</li>
-	///   <li><code>null</code>, run is commented on.</li>
-	/// </ul>
-	/// For the latter two, <code>Note</code> MUST be non-empty.
-	/// </remarks>
+	///   <ul>
+	///     <li>true, run is approved;</li>
+	///     <li>false, run is rejected;</li>
+	///     <li>null, run is commented on.</li>
+	///   </ul>
+	/// For the latter two, Note MUST be non-empty.
+	/// </summary>
 	public bool? Approved { get; set; }
 
 	/// <summary>When the judgement was made.</summary>
 	[Required]
 	public DateTime CreatedAt { get; set; }
 
-	/// <summary>Comments on the judgement.</summary>
-	/// <remarks>MUST be non-empty for rejections or comments (<code>Approved ∈ {false, null}</code>).</remarks>
+	/// <summary>
+	/// Comments on the judgement.
+	/// MUST be non-empty for rejections or comments (Approved ∈ {false, null}).
+	/// </summary>
 	[Required]
 	public string Note { get; set; } = "";
 

--- a/LeaderboardBackend/Models/Requests/JudgementRequests.cs
+++ b/LeaderboardBackend/Models/Requests/JudgementRequests.cs
@@ -1,0 +1,10 @@
+using LeaderboardBackend.Models.Annotations;
+using System.ComponentModel.DataAnnotations;
+
+namespace LeaderboardBackend.Models.Requests;
+
+/// <summary>Request object sent when creating a Judgement.</summary>
+public record CreateJudgementRequest
+{
+
+}

--- a/LeaderboardBackend/Models/Requests/JudgementRequests.cs
+++ b/LeaderboardBackend/Models/Requests/JudgementRequests.cs
@@ -6,5 +6,15 @@ namespace LeaderboardBackend.Models.Requests;
 /// <summary>Request object sent when creating a Judgement.</summary>
 public record CreateJudgementRequest
 {
+	[Required]
+	public Guid RunId;
+
+	/// <summary>See related property in model.</summary>
+	[Required]
+	[Note]
+	public string Note = "";
+
+	/// <summary>See related property in model.</summary>
+	public bool? Approved;
 
 }

--- a/LeaderboardBackend/Models/Requests/JudgementRequests.cs
+++ b/LeaderboardBackend/Models/Requests/JudgementRequests.cs
@@ -1,21 +1,14 @@
 using LeaderboardBackend.Models.Annotations;
-using System.ComponentModel.DataAnnotations;
 
 namespace LeaderboardBackend.Models.Requests;
 
 /// <summary>Request object sent when creating a Judgement.</summary>
-public record CreateJudgementRequest
-{
-	/// <summary>See related property in model.</summary>
-	[Required]
-	public Guid RunId;
-
-	/// <summary>See related property in model.</summary>
-	[Required]
-	[Note]
-	public string Note = "";
-
-	/// <summary>See related property in model.</summary>
-	public bool? Approved;
-
-}
+/// <param name="RunId">GUID of the run.</param>
+/// <param name="Note">
+///   Judgement comments. Must be provided if not outright approving a run (<paramref name="Approved"/> is false or null).
+///   Acts as mod feedback for the runner.
+/// </param>
+/// <param name="Approved">
+///   The judgement result. Can be true, false, or null. For the latter two, <paramref name="Note"/> must be non-empty.
+/// </param>
+public readonly record struct CreateJudgementRequest(Guid RunId, [Note] string Note, bool? Approved);

--- a/LeaderboardBackend/Models/Requests/JudgementRequests.cs
+++ b/LeaderboardBackend/Models/Requests/JudgementRequests.cs
@@ -6,6 +6,7 @@ namespace LeaderboardBackend.Models.Requests;
 /// <summary>Request object sent when creating a Judgement.</summary>
 public record CreateJudgementRequest
 {
+	/// <summary>See related property in model.</summary>
 	[Required]
 	public Guid RunId;
 

--- a/LeaderboardBackend/Models/ViewModels/JudgementViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/JudgementViewModel.cs
@@ -1,43 +1,45 @@
 using LeaderboardBackend.Models.Entities;
 
-namespace LeaderboardBackend.ViewModels;
+namespace LeaderboardBackend.Models.ViewModels;
 
 /// <summary>A decision by a mod on a run submission. See Models/Entities/Judgement.cs.</summary>
-public record JudgementViewModel(long Id, bool? Approved, string CreatedAt, string? Note, Guid ModId, Guid RunId)
+public record JudgementViewModel
 {
 	/// <summary>The newly-made judgement's ID.</summary>
-	internal long Id { get; set; } = Id;
+	public long Id { get; set; }
 
 	/// <summary>
 	///   The judgement result. Can be true, false, or null. In the latter two, <code>Note</code> will be non-empty.
 	/// </summary>
-	internal bool? Approved { get; set; } = Approved;
+	public bool? Approved { get; set; }
 
 	/// <summary>
 	///   When the judgement was made. Follows <a href="https://www.ietf.org/rfc/rfc3339.txt">RFC 3339</a>.
 	/// </summary>
 	/// <example>2022-01-01T12:34:56Z / 2022-01-01T12:34:56+01:00</example>
-	internal string CreatedAt { get; set; } = CreatedAt;
+	public string CreatedAt { get; set; }
 
 	/// <summary>
 	///   Judgement comments. Acts as mod feedback for the runner. Will be non-empty for
 	///   non-approval judgements (Approved is false or null).
 	/// </summary>
-	internal string? Note { get; set; } = Note;
+	public string? Note { get; set; }
 
 	/// <summary>ID of mod who made this judgement.</summary>
-	internal Guid ModId { get; set; } = ModId;
+	public Guid ModId { get; set; }
 
 	/// <summary>ID of run this judgement's for.</summary>
-	internal Guid RunId { get; set; } = RunId;
+	public Guid RunId { get; set; }
 
-	public JudgementViewModel(Judgement judgement) : this
-	(
-		judgement.Id,
-		judgement.Approved,
-		judgement.CreatedAt.ToLongDateString(),
-		judgement.Note,
-		judgement.ModId,
-		judgement.RunId
-	) {}
+	public JudgementViewModel() { }
+
+	public JudgementViewModel(Judgement judgement)
+	{
+		Id = judgement.Id;
+		Approved = judgement.Approved;
+		CreatedAt = judgement.CreatedAt.ToLongDateString();
+		Note = judgement.Note;
+		ModId = judgement.ModId;
+		RunId = judgement.RunId;
+	}
 }

--- a/LeaderboardBackend/Program.cs
+++ b/LeaderboardBackend/Program.cs
@@ -37,6 +37,7 @@ builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<ICategoryService, CategoryService>();
 builder.Services.AddScoped<IModshipService, ModshipService>();
 builder.Services.AddScoped<IParticipationService, ParticipationService>();
+builder.Services.AddScoped<IJudgementService, JudgementService>();
 
 // Add controllers to the container.
 builder.Services.AddControllers(opt =>

--- a/LeaderboardBackend/Program.cs
+++ b/LeaderboardBackend/Program.cs
@@ -38,6 +38,7 @@ builder.Services.AddScoped<ICategoryService, CategoryService>();
 builder.Services.AddScoped<IModshipService, ModshipService>();
 builder.Services.AddScoped<IParticipationService, ParticipationService>();
 builder.Services.AddScoped<IJudgementService, JudgementService>();
+builder.Services.AddScoped<IRunService, RunService>();
 
 // Add controllers to the container.
 builder.Services.AddControllers(opt =>

--- a/LeaderboardBackend/Services/IJudgementService.cs
+++ b/LeaderboardBackend/Services/IJudgementService.cs
@@ -1,0 +1,9 @@
+using LeaderboardBackend.Models.Entities;
+
+namespace LeaderboardBackend.Services;
+
+public interface IJudgementService
+{
+	Task<Judgement?> GetJudgement(long id);
+	Task CreateJudgement(Judgement judgement);
+}

--- a/LeaderboardBackend/Services/Impl/JudgementService.cs
+++ b/LeaderboardBackend/Services/Impl/JudgementService.cs
@@ -1,0 +1,24 @@
+using LeaderboardBackend.Models.Entities;
+
+namespace LeaderboardBackend.Services;
+
+public class JudgementService : IJudgementService
+{
+	private readonly ApplicationContext _applicationContext;
+
+	public JudgementService(ApplicationContext applicationContext)
+	{
+		_applicationContext = applicationContext;
+	}
+
+	public async Task<Judgement?> GetJudgement(long id)
+	{
+		return await _applicationContext.Judgements.FindAsync(id);
+	}
+
+	public async Task CreateJudgement(Judgement judgement)
+	{
+		_applicationContext.Judgements.Add(judgement);
+		await _applicationContext.SaveChangesAsync();
+	}
+}

--- a/LeaderboardBackend/ViewModels/Judgements.cs
+++ b/LeaderboardBackend/ViewModels/Judgements.cs
@@ -3,41 +3,41 @@ using LeaderboardBackend.Models.Entities;
 namespace LeaderboardBackend.ViewModels;
 
 /// <summary>A decision by a mod on a run submission. See Models/Entities/Judgement.cs.</summary>
-public record JudgementViewModel
+public record JudgementViewModel(long Id, bool? Approved, string CreatedAt, string? Note, Guid ModId, Guid RunId)
 {
 	/// <summary>The newly-made judgement's ID.</summary>
-	public long Id { get; set; }
+	internal long Id { get; set; } = Id;
 
 	/// <summary>
 	///   The judgement result. Can be true, false, or null. In the latter two, <code>Note</code> will be non-empty.
 	/// </summary>
-	public bool? Approved { get; set; }
+	internal bool? Approved { get; set; } = Approved;
 
 	/// <summary>
 	///   When the judgement was made. Follows <a href="https://www.ietf.org/rfc/rfc3339.txt">RFC 3339</a>.
 	/// </summary>
 	/// <example>2022-01-01T12:34:56Z / 2022-01-01T12:34:56+01:00</example>
-	public string CreatedAt { get; set; }
+	internal string CreatedAt { get; set; } = CreatedAt;
 
 	/// <summary>
 	///   Judgement comments. Acts as mod feedback for the runner. Will be non-empty for
 	///   non-approval judgements (Approved is false or null).
 	/// </summary>
-	public string? Note { get; set; }
+	internal string? Note { get; set; } = Note;
 
 	/// <summary>ID of mod who made this judgement.</summary>
-	public Guid ModId { get; set; }
+	internal Guid ModId { get; set; } = ModId;
 
 	/// <summary>ID of run this judgement's for.</summary>
-	public Guid RunId { get; set; }
+	internal Guid RunId { get; set; } = RunId;
 
-	public JudgementViewModel(Judgement judgement)
-	{
-		Id = judgement.Id;
-		Approved = judgement.Approved;
-		CreatedAt = judgement.CreatedAt.ToLongDateString();
-		Note = judgement.Note;
-		ModId = judgement.ModId;
-		RunId = judgement.RunId;
-	}
+	public JudgementViewModel(Judgement judgement) : this
+	(
+		judgement.Id,
+		judgement.Approved,
+		judgement.CreatedAt.ToLongDateString(),
+		judgement.Note,
+		judgement.ModId,
+		judgement.RunId
+	) {}
 }

--- a/LeaderboardBackend/ViewModels/Judgements.cs
+++ b/LeaderboardBackend/ViewModels/Judgements.cs
@@ -1,0 +1,56 @@
+namespace LeaderboardBackend.ViewModels;
+
+/// <summary>A decision by a mod on a run submission.</summary>
+/// <remarks>
+/// Refer to docs in Models/Entities/Judgement.cs.
+/// </remarks>
+public readonly record struct JudgementViewModel
+{
+	/// <summary>Generated on creation.</summary>
+	public readonly long Id;
+
+	/// <summary>
+	/// Defines this judgement, which in turn defines the status of its related run. <br />
+	/// If:
+	///   <ul>
+	///     <li>true, run is approved;</li>
+	///     <li>false, run is rejected;</li>
+	///     <li>null, run is commented on.</li>
+	///   </ul>
+	/// For the latter two, Note MUST be non-empty.
+	/// </summary>
+	/// <example>true</example>
+	public readonly bool? Approved;
+
+	/// <summary>When the judgement was made.</summary>
+	public readonly string CreatedAt;
+
+	/// <summary>
+	/// Comments on the judgement.
+	/// MUST be non-empty for rejections or comments (Approved ∈ {false, null}).
+	/// </summary>
+	public readonly string? Note;
+
+	/// <summary>ID of the mod that made this judgement.</summary>
+	public readonly Guid ModId;
+
+	/// <summary>ID of the related run.</summary>
+	public readonly Guid RunId;
+
+	public JudgementViewModel(
+		long id,
+		bool? approved,
+		DateTime createdAt,
+		string? note,
+		Guid modId,
+		Guid runId
+	)
+	{
+		Id = id;
+		Approved = approved;
+		CreatedAt = createdAt.ToLongDateString();
+		Note = note;
+		ModId = modId;
+		RunId = runId;
+	}
+}

--- a/LeaderboardBackend/ViewModels/Judgements.cs
+++ b/LeaderboardBackend/ViewModels/Judgements.cs
@@ -1,56 +1,39 @@
+using LeaderboardBackend.Models.Entities;
+
 namespace LeaderboardBackend.ViewModels;
 
-/// <summary>A decision by a mod on a run submission.</summary>
-/// <remarks>
-/// Refer to docs in Models/Entities/Judgement.cs.
-/// </remarks>
+/// <summary>A decision by a mod on a run submission. See Models/Entities/Judgement.cs.</summary>
+/// <param name="Id">The newly-made judgement's ID.</param>
+/// <param name="Approved">
+///   The judgement result. Can be true, false, or null. In the latter two, Note will be non-empty.
+/// </param>
+/// <param name="CreatedAt">
+///   When the judgement was made. Follows <a href="https://www.ietf.org/rfc/rfc3339.txt">RFC 3339</a>.
+///   E.g. 2022-01-01T12:34:56Z / 2022-01-01T12:34:56+01:00
+/// </param>
+/// <param name="Note">
+///   Judgement comments. Acts as mod feedback for the runner. Will be non-empty for
+///   non-approval judgements (Approved is false or null).
+/// </param>
+/// <param name="ModId">ID of mod who made this judgement.</param>
+/// <param name="RunId">ID of run this judgement's for.</param>
 public readonly record struct JudgementViewModel
+(
+	long Id,
+	bool? Approved,
+	string CreatedAt,
+	string? Note,
+	Guid ModId,
+	Guid RunId
+)
 {
-	/// <summary>Generated on creation.</summary>
-	public readonly long Id;
-
-	/// <summary>
-	/// Defines this judgement, which in turn defines the status of its related run. <br />
-	/// If:
-	///   <ul>
-	///     <li>true, run is approved;</li>
-	///     <li>false, run is rejected;</li>
-	///     <li>null, run is commented on.</li>
-	///   </ul>
-	/// For the latter two, Note MUST be non-empty.
-	/// </summary>
-	/// <example>true</example>
-	public readonly bool? Approved;
-
-	/// <summary>When the judgement was made.</summary>
-	public readonly string CreatedAt;
-
-	/// <summary>
-	/// Comments on the judgement.
-	/// MUST be non-empty for rejections or comments (Approved ∈ {false, null}).
-	/// </summary>
-	public readonly string? Note;
-
-	/// <summary>ID of the mod that made this judgement.</summary>
-	public readonly Guid ModId;
-
-	/// <summary>ID of the related run.</summary>
-	public readonly Guid RunId;
-
-	public JudgementViewModel(
-		long id,
-		bool? approved,
-		DateTime createdAt,
-		string? note,
-		Guid modId,
-		Guid runId
-	)
-	{
-		Id = id;
-		Approved = approved;
-		CreatedAt = createdAt.ToLongDateString();
-		Note = note;
-		ModId = modId;
-		RunId = runId;
-	}
+	public JudgementViewModel(Judgement judgement) : this
+	(
+		judgement.Id,
+		judgement.Approved,
+		judgement.CreatedAt.ToLongDateString(),
+		judgement.Note,
+		judgement.ModId,
+		judgement.RunId
+	) {}
 }

--- a/LeaderboardBackend/ViewModels/Judgements.cs
+++ b/LeaderboardBackend/ViewModels/Judgements.cs
@@ -3,37 +3,41 @@ using LeaderboardBackend.Models.Entities;
 namespace LeaderboardBackend.ViewModels;
 
 /// <summary>A decision by a mod on a run submission. See Models/Entities/Judgement.cs.</summary>
-/// <param name="Id">The newly-made judgement's ID.</param>
-/// <param name="Approved">
-///   The judgement result. Can be true, false, or null. In the latter two, Note will be non-empty.
-/// </param>
-/// <param name="CreatedAt">
-///   When the judgement was made. Follows <a href="https://www.ietf.org/rfc/rfc3339.txt">RFC 3339</a>.
-///   E.g. 2022-01-01T12:34:56Z / 2022-01-01T12:34:56+01:00
-/// </param>
-/// <param name="Note">
-///   Judgement comments. Acts as mod feedback for the runner. Will be non-empty for
-///   non-approval judgements (Approved is false or null).
-/// </param>
-/// <param name="ModId">ID of mod who made this judgement.</param>
-/// <param name="RunId">ID of run this judgement's for.</param>
-public readonly record struct JudgementViewModel
-(
-	long Id,
-	bool? Approved,
-	string CreatedAt,
-	string? Note,
-	Guid ModId,
-	Guid RunId
-)
+public record JudgementViewModel
 {
-	public JudgementViewModel(Judgement judgement) : this
-	(
-		judgement.Id,
-		judgement.Approved,
-		judgement.CreatedAt.ToLongDateString(),
-		judgement.Note,
-		judgement.ModId,
-		judgement.RunId
-	) {}
+	/// <summary>The newly-made judgement's ID.</summary>
+	public long Id { get; set; }
+
+	/// <summary>
+	///   The judgement result. Can be true, false, or null. In the latter two, <code>Note</code> will be non-empty.
+	/// </summary>
+	public bool? Approved { get; set; }
+
+	/// <summary>
+	///   When the judgement was made. Follows <a href="https://www.ietf.org/rfc/rfc3339.txt">RFC 3339</a>.
+	/// </summary>
+	/// <example>2022-01-01T12:34:56Z / 2022-01-01T12:34:56+01:00</example>
+	public string CreatedAt { get; set; }
+
+	/// <summary>
+	///   Judgement comments. Acts as mod feedback for the runner. Will be non-empty for
+	///   non-approval judgements (Approved is false or null).
+	/// </summary>
+	public string? Note { get; set; }
+
+	/// <summary>ID of mod who made this judgement.</summary>
+	public Guid ModId { get; set; }
+
+	/// <summary>ID of run this judgement's for.</summary>
+	public Guid RunId { get; set; }
+
+	public JudgementViewModel(Judgement judgement)
+	{
+		Id = judgement.Id;
+		Approved = judgement.Approved;
+		CreatedAt = judgement.CreatedAt.ToLongDateString();
+		Note = judgement.Note;
+		ModId = judgement.ModId;
+		RunId = judgement.RunId;
+	}
 }


### PR DESCRIPTION
Closes: #44

Changes:
* `*_approver_id` fields to `*_mod_id` in the DB, along with `ApproverId` and `Approver` to `ModId` and `Mod` in the backend
    * Renaming to this makes more sense IMO, as these can be rejections
* Renamed `Timestamp` to `CreatedAt` (+ migration too)
* Add code to add judgements