### PR TITLE
refactor: split up GET Bans into two separate routes.

### DIFF
--- a/LeaderboardBackend/Controllers/BansController.cs
+++ b/LeaderboardBackend/Controllers/BansController.cs
@@ -62,7 +62,7 @@ public class BansController : ControllerBase
 
 		if (bans.Count == 0)
 		{
-			return NotFound("No bans found for this User");
+			return NotFound("No bans found for this user");
 		}
 
 		return Ok(bans);

--- a/LeaderboardBackend/Controllers/BansController.cs
+++ b/LeaderboardBackend/Controllers/BansController.cs
@@ -47,8 +47,8 @@ public class BansController : ControllerBase
 		return Ok(bans);
 	}
 
-	/// <summary>Get all ban by User ID.</summary>
-	/// <param name="bannedUserId"> Gets Bans a User has.</param>
+	/// <summary>Get bans by user ID.</summary>
+	/// <param name="bannedUserId">The user ID.</param>
 	/// <response code="200">A list of bans. Can be an empty array.</response>
 	/// <response code="404">No bans found for the User.
 	/// </response>

--- a/LeaderboardBackend/Controllers/BansController.cs
+++ b/LeaderboardBackend/Controllers/BansController.cs
@@ -26,40 +26,46 @@ public class BansController : ControllerBase
 		BanService = banService;
 	}
 
-	/// <summary>Get all bans, optionally filtered by a Leaderboard or User.</summary>
-	/// <remarks>
-	/// Simply calling this without any query parameters will get all present bans. Else:
-	/// <ul>
-	///   <li>passing <code>leaderboardId</code> will return all bans a Leaderboard has</li>
-	///   <li>passing <code>bannedUserId</code> will return all bans a User has</li>
-	/// </ul>
-	/// Don't specify both a Leaderboard ID and a User ID. Only specify one.
-	/// </remarks>
-	/// <param name="leaderboardId">Optional. Gets Bans a Leaderboard has.</param>
-	/// <param name="bannedUserId">Optional. Gets Bans a User has.</param>
+	/// <summary>Get bans by leaderboard ID</summary>
+	/// <param name="leaderboardId">Gets Bans a Leaderboard has.</param>
 	/// <response code="200">A list of bans. Can be an empty array.</response>
-	/// <response code="400">
-	/// If both <code>leaderboardId</code> and <code>bannedUserId</code> are given.
+	/// <response code="404">No bans found for the Leaderboard.
 	/// </response>
 	[AllowAnonymous]
 	[ApiConventionMethod(typeof(Conventions),
-							 nameof(Conventions.Get))]
-	[HttpGet]
-	public async Task<ActionResult<List<Ban>>> GetBans([FromQuery] long? leaderboardId, [FromQuery] Guid? bannedUserId)
+							nameof(Conventions.Get))]
+	[HttpGet("leaderboard/{id:long}")]
+	public async Task<ActionResult<List<Ban>>> GetBansByLeaderboard(long leaderboardId)
 	{
-		if (leaderboardId != null && bannedUserId != null)
+		List<Ban> bans = await BanService.GetBansByLeaderboard(leaderboardId);
+
+		if (bans.Count == 0)
 		{
-			return BadRequest("Specify only either a leaderboard ID, or a user ID. Don't specify both.");
+			return NotFound("No bans found for this leaderboard");
 		}
-		if (leaderboardId != null)
+
+		return Ok(bans);
+	}
+
+	/// <summary>Get all ban by User ID.</summary>
+	/// <param name="bannedUserId"> Gets Bans a User has.</param>
+	/// <response code="200">A list of bans. Can be an empty array.</response>
+	/// <response code="404">No bans found for the User.
+	/// </response>
+	[AllowAnonymous]
+	[ApiConventionMethod(typeof(Conventions),
+							nameof(Conventions.Get))]
+	[HttpGet("leaderboard/{id:Guid}")]
+	public async Task<ActionResult<List<Ban>>> GetBansByUser(Guid bannedUserId)
+	{
+		List<Ban> bans = await BanService.GetBansByUser(bannedUserId);
+
+		if (bans.Count == 0)
 		{
-			return Ok(await BanService.GetBans(leaderboardId));
+			return NotFound("No bans found for this User");
 		}
-		if (bannedUserId != null)
-		{
-			return Ok(await BanService.GetBans(bannedUserId));
-		}
-		return Ok(await BanService.GetBans());
+
+		return Ok(bans);
 	}
 
 	/// <summary>Get a Ban from its ID.</summary>

--- a/LeaderboardBackend/Controllers/BansController.cs
+++ b/LeaderboardBackend/Controllers/BansController.cs
@@ -34,7 +34,7 @@ public class BansController : ControllerBase
 	[AllowAnonymous]
 	[ApiConventionMethod(typeof(Conventions),
 							nameof(Conventions.Get))]
-	[HttpGet("leaderboard/{id:long}")]
+	[HttpGet("leaderboard/{leaderboardId:long}")]
 	public async Task<ActionResult<List<Ban>>> GetBansByLeaderboard(long leaderboardId)
 	{
 		List<Ban> bans = await BanService.GetBansByLeaderboard(leaderboardId);
@@ -55,7 +55,7 @@ public class BansController : ControllerBase
 	[AllowAnonymous]
 	[ApiConventionMethod(typeof(Conventions),
 							nameof(Conventions.Get))]
-	[HttpGet("leaderboard/{id:Guid}")]
+	[HttpGet("leaderboard/{bannedUserId:Guid}")]
 	public async Task<ActionResult<List<Ban>>> GetBansByUser(Guid bannedUserId)
 	{
 		List<Ban> bans = await BanService.GetBansByUser(bannedUserId);

--- a/LeaderboardBackend/Controllers/BansController.cs
+++ b/LeaderboardBackend/Controllers/BansController.cs
@@ -27,7 +27,7 @@ public class BansController : ControllerBase
 	}
 
 	/// <summary>Get bans by leaderboard ID</summary>
-	/// <param name="leaderboardId">Gets Bans a Leaderboard has.</param>
+	/// <param name="leaderboardId">The leaderboard ID.</param>
 	/// <response code="200">A list of bans. Can be an empty array.</response>
 	/// <response code="404">No bans found for the Leaderboard.
 	/// </response>

--- a/LeaderboardBackend/Services/IBanService.cs
+++ b/LeaderboardBackend/Services/IBanService.cs
@@ -6,7 +6,11 @@ public interface IBanService
 {
 	Task<Ban?> GetBanById(ulong id);
 
-	Task<List<Ban>> GetBans(object? filter = null);
+	Task<List<Ban>> GetBans();
+
+	Task<List<Ban>> GetBansByLeaderboard(long leaderboardId);
+
+	Task<List<Ban>> GetBansByUser(Guid userId);
 
 	Task CreateBan(Ban user);
 }

--- a/LeaderboardBackend/Services/Impl/BanService.cs
+++ b/LeaderboardBackend/Services/Impl/BanService.cs
@@ -18,25 +18,23 @@ public class BanService : IBanService
 		return await ApplicationContext.Bans.FindAsync(id);
 	}
 
-	public async Task<List<Ban>> GetBans(object? filter = null)
+	public async Task<List<Ban>> GetBans()
 	{
-		if (filter is null)
-		{
-			return await ApplicationContext.Bans.ToListAsync();
-		}
-		if (filter.GetType() == typeof(ulong))
-		{
-			return await ApplicationContext.Bans.Where(
-				b => b.LeaderboardId != null && b.LeaderboardId == (long)filter
-			).ToListAsync();
-		}
-		if (filter is Guid)
-		{
-			return await ApplicationContext.Bans.Where(
-				b => b.BannedUserId == (Guid)filter
-			).ToListAsync();
-		}
-		return new List<Ban>();
+		return await ApplicationContext.Bans.ToListAsync();
+	}
+
+	public async Task<List<Ban>> GetBansByLeaderboard(long leaderboardId)
+	{
+		return await ApplicationContext.Bans.Where(
+			b => b.LeaderboardId == leaderboardId
+		).ToListAsync();
+	}
+
+	public async Task<List<Ban>> GetBansByUser(Guid userId)
+	{
+		return await ApplicationContext.Bans.Where(
+			b => b.BannedUserId == userId
+		).ToListAsync();
 	}
 
 	public async Task CreateBan(Ban ban)


### PR DESCRIPTION
Refactor of the GET Bans method into two separate routes, one for leaderboard ID and one for user ID. Dropped route for GET all bans.