### PR TITLE
39 participations

### DIFF
--- a/LeaderboardBackend.Test/Runs.cs
+++ b/LeaderboardBackend.Test/Runs.cs
@@ -1,6 +1,3 @@
-using System.Net;
-using System.Net.Http;
-using System.Text.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/LeaderboardBackend.Test/Runs.cs
+++ b/LeaderboardBackend.Test/Runs.cs
@@ -57,7 +57,7 @@ namespace LeaderboardBackend.Test
 			);
 
 			List<Participation> retrieved = await ApiClient.Get<List<Participation>>(
-				$"api/runs/participations/{createdRun.Id}",
+				$"api/runs/{createdRun.Id}/participations",
 				new()
 				{
 					Jwt = Jwt

--- a/LeaderboardBackend.Test/Runs.cs
+++ b/LeaderboardBackend.Test/Runs.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LeaderboardBackend.Models.Entities;
+using LeaderboardBackend.Models.Requests;
+using LeaderboardBackend.Test.Lib;
+using LeaderboardBackend.Test.TestApi;
+using LeaderboardBackend.Test.TestApi.Extensions;
+using NUnit.Framework;
+
+namespace LeaderboardBackend.Test
+{
+	[TestFixture]
+	internal class Runs
+	{
+		private static TestApiFactory Factory = null!;
+		private static TestApiClient ApiClient = null!;
+		private static string Jwt = null!;
+
+		[SetUp]
+		public static async Task SetUp()
+		{
+			Factory = new TestApiFactory();
+			ApiClient = Factory.CreateTestApiClient();
+			Jwt = (await ApiClient.LoginAdminUser()).Token;
+		}
+
+		[Test]
+		public static async Task CreateRun_OK()
+		{
+			Run created = await CreateRun();
+
+			Run retrieved = await GetRun(created.Id);
+
+			Assert.NotNull(created);
+			Assert.AreEqual(created.Id, retrieved.Id);
+		}
+
+		[Test]
+		public static async Task GetParticipation_OK()
+		{
+			Run createdRun = await CreateRun();
+
+			Participation createdParticipation = await ApiClient.Post<Participation>(
+				"api/participations",
+				new()
+				{
+					Body = new CreateParticipationRequest
+					{
+						Comment = "comment",
+						Vod = "vod",
+						RunId = createdRun.Id,
+						RunnerId = TestInitCommonFields.Admin.Id
+					},
+					Jwt = Jwt
+				}
+			);
+
+			List<Participation> retrieved = await ApiClient.Get<List<Participation>>(
+				$"api/runs/participations/{createdRun.Id}",
+				new()
+				{
+					Jwt = Jwt
+				}
+			);
+
+			Assert.NotNull(retrieved);
+			Assert.AreEqual(createdParticipation.Id, retrieved[0].Id);
+		}
+
+		private static async Task<Run> CreateRun()
+		{
+			return await ApiClient.Post<Run>(
+				"/api/runs",
+				new()
+				{
+					Body = new CreateRunRequest
+					{
+						Played = DateTime.MinValue,
+						Submitted = DateTime.MaxValue,
+						Status = RunStatus.CREATED
+					},
+					Jwt = Jwt
+				}
+			);
+		}
+
+		private static async Task<Run> GetRun(Guid id)
+		{
+			return await ApiClient.Get<Run>(
+				$"/api/runs/{id}",
+				new()
+				{
+					Jwt = Jwt
+				}
+			);
+		}
+
+	}
+}

--- a/LeaderboardBackend/Controllers/RunsController.cs
+++ b/LeaderboardBackend/Controllers/RunsController.cs
@@ -71,6 +71,10 @@ public class RunsController : ControllerBase
 
 		List<Participation> participations = await ParticipationService.GetParticipationsForRun(run);
 
+		if (!participations.Any())
+		{
+			return NotFound();
+		}
 
 		return Ok(participations);
 	}

--- a/LeaderboardBackend/Controllers/RunsController.cs
+++ b/LeaderboardBackend/Controllers/RunsController.cs
@@ -11,10 +11,12 @@ namespace LeaderboardBackend.Controllers;
 public class RunsController : ControllerBase
 {
 	private readonly IRunService RunService;
+	private readonly IParticipationService ParticipationService;
 
-	public RunsController(IRunService runService)
+	public RunsController(IRunService runService, IParticipationService participationService)
 	{
 		RunService = runService;
+		ParticipationService = participationService;
 	}
 
 	/// <summary>Gets a Run.</summary>
@@ -50,5 +52,30 @@ public class RunsController : ControllerBase
 
 		await RunService.CreateRun(run);
 		return CreatedAtAction(nameof(GetRun), new { id = run.Id }, run);
+	}
+
+	/// <summary>Gets the Participations for a Run.</summary>
+	/// <param name="id">The Run ID.</param>
+	/// <response code="200">An array with all participations.</response>
+	/// <response code="404">If the run is not found or the run has no participations.</response>
+	[ApiConventionMethod(typeof(Conventions),
+						 nameof(Conventions.Get))]
+	[HttpGet("participations/{id}")]
+	public async Task<ActionResult<List<Participation>>> GetParticipations(Guid id)
+	{
+		Run? run = await RunService.GetRun(id);
+		if (run is null)
+		{
+			return NotFound();
+		}
+
+		List<Participation> participations = await ParticipationService.GetParticipationForRun(run);
+
+		if (participations.Count == 0)
+		{
+			return NotFound();
+		}
+
+		return Ok(participations);
 	}
 }

--- a/LeaderboardBackend/Controllers/RunsController.cs
+++ b/LeaderboardBackend/Controllers/RunsController.cs
@@ -56,8 +56,8 @@ public class RunsController : ControllerBase
 
 	/// <summary>Gets the Participations for a Run.</summary>
 	/// <param name="id">The Run ID.</param>
-	/// <response code="200">An array with all participations.</response>
-	/// <response code="404">If the run is not found or the run has no participations.</response>
+	/// <response code="200">An array with all participations. Can be empty</response>
+	/// <response code="404">If the run is not found.</response>
 	[ApiConventionMethod(typeof(Conventions),
 						 nameof(Conventions.Get))]
 	[HttpGet("participations/{id}")]
@@ -70,11 +70,6 @@ public class RunsController : ControllerBase
 		}
 
 		List<Participation> participations = await ParticipationService.GetParticipationForRun(run);
-
-		if (participations.Count == 0)
-		{
-			return NotFound();
-		}
 
 		return Ok(participations);
 	}

--- a/LeaderboardBackend/Controllers/RunsController.cs
+++ b/LeaderboardBackend/Controllers/RunsController.cs
@@ -54,13 +54,13 @@ public class RunsController : ControllerBase
 		return CreatedAtAction(nameof(GetRun), new { id = run.Id }, run);
 	}
 
-	/// <summary>Gets the Participations for a Run.</summary>
-	/// <param name="id">The Run ID.</param>
-	/// <response code="200">An array with all participations. Can be empty</response>
-	/// <response code="404">If the run is not found.</response>
+	/// <summary>Gets the participations for a run.</summary>
+	/// <param name="id">The run ID.</param>
+	/// <response code="200">An array with all participations.</response>
+	/// <response code="404">If the run or no participations are found.</response>
 	[ApiConventionMethod(typeof(Conventions),
 						 nameof(Conventions.Get))]
-	[HttpGet("participations/{id}")]
+	[HttpGet("{id}/participations")]
 	public async Task<ActionResult<List<Participation>>> GetParticipations(Guid id)
 	{
 		Run? run = await RunService.GetRun(id);

--- a/LeaderboardBackend/Controllers/RunsController.cs
+++ b/LeaderboardBackend/Controllers/RunsController.cs
@@ -69,7 +69,8 @@ public class RunsController : ControllerBase
 			return NotFound();
 		}
 
-		List<Participation> participations = await ParticipationService.GetParticipationForRun(run);
+		List<Participation> participations = await ParticipationService.GetParticipationsForRun(run);
+
 
 		return Ok(participations);
 	}

--- a/LeaderboardBackend/Services/IParticipationService.cs
+++ b/LeaderboardBackend/Services/IParticipationService.cs
@@ -8,5 +8,5 @@ public interface IParticipationService
 	Task<Participation?> GetParticipationForUser(User user);
 	Task CreateParticipation(Participation participation);
 	Task UpdateParticipation(Participation participation);
-	Task<List<Participation>> GetParticipationForRun(Run run);
+	Task<List<Participation>> GetParticipationsForRun(Run run);
 }

--- a/LeaderboardBackend/Services/IParticipationService.cs
+++ b/LeaderboardBackend/Services/IParticipationService.cs
@@ -8,4 +8,5 @@ public interface IParticipationService
 	Task<Participation?> GetParticipationForUser(User user);
 	Task CreateParticipation(Participation participation);
 	Task UpdateParticipation(Participation participation);
+	Task<List<Participation>> GetParticipationForRun(Run run);
 }

--- a/LeaderboardBackend/Services/Impl/ParticipationService.cs
+++ b/LeaderboardBackend/Services/Impl/ParticipationService.cs
@@ -33,4 +33,9 @@ public class ParticipationService : IParticipationService
 		ApplicationContext.Participations.Update(participation);
 		await ApplicationContext.SaveChangesAsync();
 	}
+
+	public async Task<List<Participation>> GetParticipationForRun(Run run)
+	{
+		return await ApplicationContext.Participations.Where(p => p.RunId == run.Id).ToListAsync();
+	}
 }

--- a/LeaderboardBackend/Services/Impl/ParticipationService.cs
+++ b/LeaderboardBackend/Services/Impl/ParticipationService.cs
@@ -34,7 +34,7 @@ public class ParticipationService : IParticipationService
 		await ApplicationContext.SaveChangesAsync();
 	}
 
-	public async Task<List<Participation>> GetParticipationForRun(Run run)
+	public async Task<List<Participation>> GetParticipationsForRun(Run run)
 	{
 		return await ApplicationContext.Participations.Where(p => p.RunId == run.Id).ToListAsync();
 	}


### PR DESCRIPTION
Closes #39 GET Participations for Run as API client with ID (long; pk)