### PR TITLE
Added AuthService method to get jwt claims

### DIFF
--- a/LeaderboardBackend/Controllers/ParticipationsController.cs
+++ b/LeaderboardBackend/Controllers/ParticipationsController.cs
@@ -14,16 +14,19 @@ public class ParticipationsController : ControllerBase
 	private readonly IParticipationService ParticipationService;
 	private readonly IRunService RunService;
 	private readonly IUserService UserService;
+	private readonly IAuthService AuthService;
 
 	public ParticipationsController(
 		IParticipationService participationService,
 		IRunService runService,
-		IUserService userService
+		IUserService userService,
+		IAuthService authService
 	)
 	{
 		ParticipationService = participationService;
 		RunService = runService;
 		UserService = userService;
+		AuthService = authService;
 	}
 
 	[ApiConventionMethod(typeof(Conventions),
@@ -81,12 +84,12 @@ public class ParticipationsController : ControllerBase
 	[HttpPut]
 	public async Task<ActionResult> UpdateParticipation([FromBody] UpdateParticipationRequest request)
 	{
-		User? user = await UserService.GetUserFromClaims(HttpContext.User);
-		if (user is null)
+		Guid? userId = AuthService.GetUserIdFromClaims(HttpContext.User);
+		if (userId is null)
 		{
 			return Forbid();
 		}
-		Participation? participation = await ParticipationService.GetParticipationForUser(user);
+		Participation? participation = await ParticipationService.GetParticipationForUser(userId.Value);
 		if (participation is null)
 		{
 			return NotFound();

--- a/LeaderboardBackend/Controllers/UsersController.cs
+++ b/LeaderboardBackend/Controllers/UsersController.cs
@@ -120,7 +120,16 @@ public class UsersController : ControllerBase
 	[HttpGet("me")]
 	public async Task<ActionResult<User>> Me()
 	{
-		User? user = await UserService.GetUserFromClaims(HttpContext.User);
-		return user is not null ? Ok(user) : Forbid();
+		string? email = AuthService.GetEmailFromClaims(HttpContext.User);
+		if (email is null)
+		{
+			return Forbid();
+		}
+		User? user = await UserService.GetUserByEmail(email);
+		if (user is null)
+		{
+			return Forbid();
+		}
+		return Ok(user);
 	}
 }

--- a/LeaderboardBackend/Services/IAuthService.cs
+++ b/LeaderboardBackend/Services/IAuthService.cs
@@ -6,6 +6,6 @@ namespace LeaderboardBackend.Services;
 public interface IAuthService
 {
 	string GenerateJSONWebToken(User user);
-	public string? GetEmailFromClaims(ClaimsPrincipal claims);
-	public Guid? GetUserIdFromClaims(ClaimsPrincipal claims);
+	string? GetEmailFromClaims(ClaimsPrincipal claims);
+	Guid? GetUserIdFromClaims(ClaimsPrincipal claims);
 }

--- a/LeaderboardBackend/Services/IAuthService.cs
+++ b/LeaderboardBackend/Services/IAuthService.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using LeaderboardBackend.Models.Entities;
 
 namespace LeaderboardBackend.Services;
@@ -5,4 +6,6 @@ namespace LeaderboardBackend.Services;
 public interface IAuthService
 {
 	string GenerateJSONWebToken(User user);
+	public string? GetEmailFromClaims(ClaimsPrincipal claims);
+	public Guid? GetUserIdFromClaims(ClaimsPrincipal claims);
 }

--- a/LeaderboardBackend/Services/IParticipationService.cs
+++ b/LeaderboardBackend/Services/IParticipationService.cs
@@ -5,7 +5,7 @@ namespace LeaderboardBackend.Services;
 public interface IParticipationService
 {
 	Task<Participation?> GetParticipation(long id);
-	Task<Participation?> GetParticipationForUser(User user);
+	Task<Participation?> GetParticipationForUser(Guid userId);
 	Task CreateParticipation(Participation participation);
 	Task UpdateParticipation(Participation participation);
 	Task<List<Participation>> GetParticipationsForRun(Run run);

--- a/LeaderboardBackend/Services/IUserService.cs
+++ b/LeaderboardBackend/Services/IUserService.cs
@@ -8,6 +8,5 @@ public interface IUserService
 	Task<User?> GetUserById(Guid id);
 	Task<User?> GetUserByEmail(string email);
 	Task<User?> GetUserByName(string name);
-	Task<User?> GetUserFromClaims(ClaimsPrincipal claims);
 	Task CreateUser(User user);
 }

--- a/LeaderboardBackend/Services/Impl/AuthService.cs
+++ b/LeaderboardBackend/Services/Impl/AuthService.cs
@@ -37,4 +37,26 @@ public class AuthService : IAuthService
 
 		return new JwtSecurityTokenHandler().WriteToken(token);
 	}
+
+	public string? GetEmailFromClaims(ClaimsPrincipal claims)
+	{
+		return claims.FindFirstValue(JwtRegisteredClaimNames.Email);
+	}
+
+	public Guid? GetUserIdFromClaims(ClaimsPrincipal claims)
+	{
+		string? userIdStr = claims.FindFirstValue(JwtRegisteredClaimNames.Sub);
+		if (userIdStr is null)
+		{
+			return null;
+		}
+
+		Guid? userId = null;
+		try
+		{
+			userId = Guid.Parse(userIdStr);
+		} catch (FormatException) { }
+
+		return userId;
+	}
 }

--- a/LeaderboardBackend/Services/Impl/ParticipationService.cs
+++ b/LeaderboardBackend/Services/Impl/ParticipationService.cs
@@ -17,9 +17,9 @@ public class ParticipationService : IParticipationService
 		return participation;
 	}
 
-	public async Task<Participation?> GetParticipationForUser(User user)
+	public async Task<Participation?> GetParticipationForUser(Guid userId)
 	{
-		return await ApplicationContext.Participations.SingleOrDefaultAsync(p => p.RunnerId == user.Id);
+		return await ApplicationContext.Participations.SingleOrDefaultAsync(p => p.RunnerId == userId);
 	}
 
 	public async Task CreateParticipation(Participation participation)

--- a/LeaderboardBackend/Services/Impl/UserService.cs
+++ b/LeaderboardBackend/Services/Impl/UserService.cs
@@ -31,17 +31,6 @@ public class UserService : IUserService
 		return await ApplicationContext.Users.FirstOrDefaultAsync(u => u.Username != null && u.Username.ToLower() == name.ToLower());
 	}
 
-	public async Task<User?> GetUserFromClaims(ClaimsPrincipal claims)
-	{
-		if (!claims.HasClaim(c => c.Type == JwtRegisteredClaimNames.Email))
-		{
-			return null;
-		}
-
-		string email = claims.FindFirstValue("Email");
-		return await GetUserByEmail(email);
-	}
-
 	public async Task CreateUser(User user)
 	{
 		ApplicationContext.Users.Add(user);


### PR DESCRIPTION
Added `GetUserIdFromClaims` and `GetEmailFromClaims` to the AuthService,
and use those instead of a UserService method to get the user from
claims. This makes for a more sane pattern throughout controllers using
claim data, and reduces database calls.