### PR TITLE
Refactor AuthZ Handler

### DIFF
--- a/LeaderboardBackend/Authorization/MiddlewareResultHandler.cs
+++ b/LeaderboardBackend/Authorization/MiddlewareResultHandler.cs
@@ -15,11 +15,8 @@ public class MiddlewareResultHandler : IAuthorizationMiddlewareResultHandler
 		AuthorizationPolicy authorizationPolicy,
 		PolicyAuthorizationResult policyAuthorizationResult)
 	{
-		if (policyAuthorizationResult.Forbidden)
-		{
-			httpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
-			return;
-		}
+		// FIXME: For now, we're doing a simple pass-through. In the future we'd want to
+		// conditionally return a redirect to the login page. -zysim
 
 		// Fallback to the default implementation.
 		// This can mean calling the controller action itself.

--- a/LeaderboardBackend/Authorization/UserTypeAuthorizationHandler.cs
+++ b/LeaderboardBackend/Authorization/UserTypeAuthorizationHandler.cs
@@ -1,4 +1,5 @@
 using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
 using LeaderboardBackend.Models.Entities;
 using LeaderboardBackend.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -6,6 +7,9 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace LeaderboardBackend.Authorization;
 
+// FIXME: This should be reimplemented with the role-based authz thingy:
+// https://github.com/leaderboardsgg/leaderboard-backend/issues/104
+// - zysim
 public class UserTypeAuthorizationHandler : AuthorizationHandler<UserTypeRequirement>
 {
 	private readonly JwtSecurityTokenHandler JwtHandler;
@@ -35,22 +39,26 @@ public class UserTypeAuthorizationHandler : AuthorizationHandler<UserTypeRequire
 	{
 		if (!TryGetJwtFromHttpContext(context, out string token) || !ValidateJwt(token))
 		{
-			return Task.CompletedTask;
+			return Fail(context);
 		}
 
 		Guid? userId = AuthService.GetUserIdFromClaims(context.User);
 		if (userId is null)
 		{
-			context.Fail();
-			return Task.CompletedTask;
+			return Fail(context);
 		}
-		User? user = UserService.GetUserById(userId.Value).Result;
 
-		if (user is null || !Handle(user, context, requirement))
+		User? user = UserService.GetUserById(userId.Value).Result;
+		if (user is null)
 		{
-			// FIXME: Work out how to fail as a ForbiddenResult.
-			context.Fail();
-			return Task.CompletedTask;
+			return Fail(context);
+		}
+
+		AddRoleClaimToContext(user, context);
+
+		if (!IsAuthorized(context, requirement))
+		{
+			return Fail(context);
 		}
 
 		context.Succeed(requirement);
@@ -58,17 +66,24 @@ public class UserTypeAuthorizationHandler : AuthorizationHandler<UserTypeRequire
 		return Task.CompletedTask;
 	}
 
-	private bool Handle(
-		User user,
-		AuthorizationHandlerContext _,
-		UserTypeRequirement requirement
-	) => requirement.Type switch
+	private void AddRoleClaimToContext(User user, AuthorizationHandlerContext context)
 	{
-		UserTypes.Admin => user.Admin,
-		UserTypes.Mod => user.Admin || IsMod(user),
-		UserTypes.User => true,
-		_ => false,
-	};
+		if (user.Admin)
+		{
+			context.User.AddIdentity(new(new Claim[] { new("role", UserTypes.Admin) }));
+			return;
+		}
+		if (IsMod(user))
+		{
+			context.User.AddIdentity(new(new Claim[] { new("role", UserTypes.Mod) }));
+			return;
+		}
+	}
+
+	private bool IsAuthorized(
+		AuthorizationHandlerContext context,
+		UserTypeRequirement requirement
+	) => context.User.HasClaim("role", requirement.Type) || context.User.HasClaim("role", UserTypes.Admin);
 
 	private bool IsMod(User user) => ModshipService.LoadUserModships(user.Id).Result.Count() > 0;
 
@@ -108,5 +123,17 @@ public class UserTypeAuthorizationHandler : AuthorizationHandler<UserTypeRequire
 		{
 			return false;
 		}
+	}
+
+	private Task Fail(AuthorizationHandlerContext context, string? reason = null)
+	{
+		if (reason is not null)
+		{
+			context.Fail(new(this, reason));
+		} else
+		{
+			context.Fail();
+		}
+		return Task.CompletedTask;
 	}
 }

--- a/LeaderboardBackend/Controllers/ParticipationsController.cs
+++ b/LeaderboardBackend/Controllers/ParticipationsController.cs
@@ -89,6 +89,7 @@ public class ParticipationsController : ControllerBase
 
 	/// <summary>Updates the participation of a user for a run.</summary>
 	/// <remarks>Expects both a comment and a VoD link.</remarks>
+	/// <param name="id">The run ID.</param>
 	/// <param name="request">The request body.</param>
 	/// <response code="200">A successful update.</response>
 	/// <response code="404">The participation could not be found.</response>


### PR DESCRIPTION
Changes `UserTypeAuthorizationHandler.cs` to add the user role to the ClaimsPrincipal (controller context object) before evaluating authorisation. This means we can simply call `HttpContext.User.HasClaim("role", UserTypes.<whatever>)` in controller actions to get the already-authorised user's role.