### PR TITLE
Migrate run_status from Int to Enum

### DIFF
--- a/LeaderboardBackend.Test/TestApi/TestApiFactory.cs
+++ b/LeaderboardBackend.Test/TestApi/TestApiFactory.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using BCryptNet = BCrypt.Net.BCrypt;
+using Npgsql;
 
 namespace LeaderboardBackend.Test.TestApi;
 
@@ -33,6 +34,10 @@ internal class TestApiFactory : WebApplicationFactory<Program>
 			else
 			{
 				dbContext.Database.Migrate();
+				NpgsqlConnection conn = (NpgsqlConnection)dbContext.Database.GetDbConnection();
+				conn.Open();
+				conn.ReloadTypes();
+				conn.Close();
 			}
 
 			Seed(dbContext);

--- a/LeaderboardBackend/Migrations/20221005132526_Run_UseEnumTypeForRunStatus.Designer.cs
+++ b/LeaderboardBackend/Migrations/20221005132526_Run_UseEnumTypeForRunStatus.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LeaderboardBackend.Models.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LeaderboardBackend.Migrations
 {
     [DbContext(typeof(ApplicationContext))]
-    partial class ApplicationContextModelSnapshot : ModelSnapshot
+    [Migration("20221005132526_Run_UseEnumTypeForRunStatus")]
+    partial class Run_UseEnumTypeForRunStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/LeaderboardBackend/Migrations/20221005132526_Run_UseEnumTypeForRunStatus.cs
+++ b/LeaderboardBackend/Migrations/20221005132526_Run_UseEnumTypeForRunStatus.cs
@@ -1,0 +1,39 @@
+﻿using LeaderboardBackend.Models.Entities;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LeaderboardBackend.Migrations
+{
+	public partial class Run_UseEnumTypeForRunStatus : Migration
+	{
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.AlterDatabase()
+				.Annotation("Npgsql:Enum:run_status", "created,submitted,pending,approved,rejected");
+
+			// Custom SQL to convert int to enum, as EF Core can't do it automatically.
+			// https://w.wol.ph/2020/03/18/altering-postgres-int-columns-to-enum-type/
+			migrationBuilder.Sql(
+				@"ALTER TABLE runs
+				ALTER COLUMN status
+				TYPE run_status
+				USING (enum_range(null::run_status))[status::int + 1];"
+			);
+		}
+
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			// Custom SQL to revert, as EF Core can't do it automatically.
+			migrationBuilder.Sql(
+				@"ALTER TABLE runs
+				ALTER status
+				TYPE integer
+				USING array_length(enum_range(NULL, status::run_status), 1) - 1;"
+			);
+
+			migrationBuilder.AlterDatabase()
+				.OldAnnotation("Npgsql:Enum:run_status", "created,submitted,pending,approved,rejected");
+		}
+	}
+}

--- a/LeaderboardBackend/Models/Entities/ApplicationContext.cs
+++ b/LeaderboardBackend/Models/Entities/ApplicationContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 
 namespace LeaderboardBackend.Models.Entities;
 
@@ -16,8 +17,15 @@ public class ApplicationContext : DbContext
 	public DbSet<Run> Runs { get; set; } = null!;
 	public DbSet<User> Users { get; set; } = null!;
 
+	static ApplicationContext()
+	{
+		NpgsqlConnection.GlobalTypeMapper.MapEnum<RunStatus>();
+	}
+
 	protected override void OnModelCreating(ModelBuilder modelBuilder)
 	{
+		modelBuilder.HasPostgresEnum<RunStatus>();
+
 		modelBuilder.Entity<Judgement>()
 			.Property(judgement => judgement.CreatedAt)
 			.HasDefaultValueSql("now()");


### PR DESCRIPTION
Figured we'd want to actually map our C# enums to Postgres enums after all. Kicking things off by migrating our one enum type, `RunStatus`, to be that.