### PR TITLE
Strongly typed configuration + validation

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -18,6 +18,6 @@ jobs:
         - name: Spin up containers
           run: docker compose up -d
         - name: Run Tests on In Memory Database
-          run: USE_IN_MEMORY_DB=true dotnet test LeaderboardBackend.Test
+          run: ApplicationContext__UseInMemoryDb=true dotnet test LeaderboardBackend.Test
         - name: Run Tests on Test Postgres Database
-          run: USE_IN_MEMORY_DB=false dotnet test LeaderboardBackend.Test
+          run: ApplicationContext__UseInMemoryDb=false dotnet test LeaderboardBackend.Test

--- a/LeaderboardBackend.Test/TestApi/TestApiFactory.cs
+++ b/LeaderboardBackend.Test/TestApi/TestApiFactory.cs
@@ -21,6 +21,18 @@ internal class TestApiFactory : WebApplicationFactory<Program>
 
 		builder.ConfigureServices(services =>
 		{
+			int testPort = DotNetEnv.Env.GetInt("POSTGRES_TEST_PORT", -1);
+			if (testPort >= 0)
+			{
+				services.Configure<ApplicationContextConfig>(conf =>
+				{
+					if (conf.Pg is not null)
+					{
+						conf.Pg.Port = (ushort)testPort;
+					}
+				});
+			}
+
 			// Reset the database on every test run
 			using ServiceProvider scope = services.BuildServiceProvider();
 			ApplicationContext dbContext = scope.GetRequiredService<ApplicationContext>();

--- a/LeaderboardBackend/AppConfig.cs
+++ b/LeaderboardBackend/AppConfig.cs
@@ -1,0 +1,7 @@
+namespace LeaderboardBackend;
+
+public class AppConfig
+{
+	public string? EnvPath { get; set; } = ".env";
+}
+

--- a/LeaderboardBackend/Authorization/Jwt.cs
+++ b/LeaderboardBackend/Authorization/Jwt.cs
@@ -10,28 +10,25 @@ namespace LeaderboardBackend.Authorization;
 /// </summary>
 public static class Jwt
 {
-	public const string KEY = "Jwt:Key";
-	public const string ISSUER = "Jwt:Issuer";
-
 	public static JwtSecurityTokenHandler SecurityTokenHandler { get; } = new();
 
 	public static class ValidationParameters
 	{
 		private static TokenValidationParameters? s_Instance;
 
-		public static TokenValidationParameters GetInstance(IConfiguration configuration)
+		public static TokenValidationParameters GetInstance(JwtConfig config)
 		{
 			if (s_Instance is not null)
 			{
 				return s_Instance;
 			}
 
-			SymmetricSecurityKey key = new(Encoding.UTF8.GetBytes(configuration[KEY]));
+			SymmetricSecurityKey key = new(Encoding.UTF8.GetBytes(config.Key));
 			s_Instance = new()
 			{
 				IssuerSigningKey = key,
-				ValidAudience = configuration[ISSUER],
-				ValidIssuer = configuration[ISSUER]
+				ValidAudience = config.Issuer,
+				ValidIssuer = config.Issuer
 			};
 
 			return s_Instance;

--- a/LeaderboardBackend/Authorization/JwtConfig.cs
+++ b/LeaderboardBackend/Authorization/JwtConfig.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LeaderboardBackend.Authorization;
+
+public class JwtConfig
+{
+	public const string KEY = "Jwt";
+
+	[Required]
+	public required string Key { get; set; }
+	[Required]
+	public required string Issuer { get; set; }
+}

--- a/LeaderboardBackend/Authorization/UserTypeAuthorizationHandler.cs
+++ b/LeaderboardBackend/Authorization/UserTypeAuthorizationHandler.cs
@@ -1,8 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
-using System.IdentityModel.Tokens.Jwt;
 using LeaderboardBackend.Models.Entities;
 using LeaderboardBackend.Services;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 
 namespace LeaderboardBackend.Authorization;
@@ -16,12 +16,12 @@ public class UserTypeAuthorizationHandler : AuthorizationHandler<UserTypeRequire
 
 	public UserTypeAuthorizationHandler(
 		IAuthService authService,
-		IConfiguration config,
+		IOptions<JwtConfig> config,
 		IModshipService modshipService,
 		IUserService userService)
 	{
 		_authService = authService;
-		_jwtValidationParams = Jwt.ValidationParameters.GetInstance(config);
+		_jwtValidationParams = Jwt.ValidationParameters.GetInstance(config.Value);
 		_modshipService = modshipService;
 		_userService = userService;
 	}

--- a/LeaderboardBackend/LeaderboardBackend.csproj
+++ b/LeaderboardBackend/LeaderboardBackend.csproj
@@ -21,7 +21,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
-		<PackageReference Include="dotenv.net" Version="3.1.2" />
+		<PackageReference Include="DotNetEnv" Version="2.5.0" />
 		<PackageReference Include="EFCore.NamingConventions" Version="7.0.2" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.2" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.2">
@@ -33,6 +33,7 @@
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.3" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.1" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="7.0.1" />
+		<PackageReference Include="ReHackt.Extensions.Options.Validation" Version="7.0.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
 	</ItemGroup>
 

--- a/LeaderboardBackend/Models/Entities/ApplicationContextConfig.cs
+++ b/LeaderboardBackend/Models/Entities/ApplicationContextConfig.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LeaderboardBackend.Models.Entities;
+
+public class ApplicationContextConfig : IValidatableObject
+{
+	public const string KEY = "ApplicationContext";
+
+	public bool MigrateDb { get; set; } = false;
+	public bool UseInMemoryDb { get; set; } = false;
+	public PostgresConfig? Pg { get; set; }
+
+	public IEnumerable<ValidationResult> Validate(ValidationContext context)
+	{
+		if (!UseInMemoryDb && Pg == null)
+		{
+			yield return new ValidationResult("Missing database configuration.", new[]
+			{
+				nameof(UseInMemoryDb),
+				nameof(Pg)
+			});
+		}
+	}
+}
+
+public class PostgresConfig
+{
+	[Required]
+	public required string Host { get; set; }
+	[Required]
+	public required string User { get; set; }
+	[Required]
+	public required string Password { get; set; }
+	[Required]
+	public required string Db { get; set; }
+	public ushort? Port { get; set; }
+}

--- a/LeaderboardBackend/Services/Impl/AuthService.cs
+++ b/LeaderboardBackend/Services/Impl/AuthService.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using System.Text;
 using LeaderboardBackend.Authorization;
 using LeaderboardBackend.Models.Entities;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 
 namespace LeaderboardBackend.Services;
@@ -12,12 +13,13 @@ public class AuthService : IAuthService
 	private readonly SigningCredentials _credentials;
 	private readonly string _issuer;
 
-	public AuthService(IConfiguration config)
+	public AuthService(IOptions<JwtConfig> options)
 	{
-		SymmetricSecurityKey? securityKey = new(Encoding.UTF8.GetBytes(config[Jwt.KEY]));
+		JwtConfig config = options.Value;
+		SymmetricSecurityKey? securityKey = new(Encoding.UTF8.GetBytes(config.Key));
 
 		_credentials = new(securityKey, SecurityAlgorithms.HmacSha256);
-		_issuer = config[Jwt.ISSUER];
+		_issuer = config.Issuer;
 	}
 
 	public string GenerateJSONWebToken(User user)

--- a/LeaderboardBackend/Services/Impl/BanService.cs
+++ b/LeaderboardBackend/Services/Impl/BanService.cs
@@ -7,12 +7,10 @@ namespace LeaderboardBackend.Services;
 public class BanService : IBanService
 {
 	private readonly ApplicationContext _applicationContext;
-	private readonly IConfiguration _config;
 
-	public BanService(ApplicationContext applicationContext, IConfiguration config)
+	public BanService(ApplicationContext applicationContext)
 	{
 		_applicationContext = applicationContext;
-		_config = config;
 	}
 
 	public async Task<Ban?> GetBanById(long id)

--- a/LeaderboardBackend/appsettings.Development.json
+++ b/LeaderboardBackend/appsettings.Development.json
@@ -19,8 +19,5 @@
 				"Url": "https://localhost:8080"
 			}
 		}
-	},
-	"Db": {
-		"PortVar": "POSTGRES_PORT"
 	}
 }

--- a/LeaderboardBackend/appsettings.Staging.json
+++ b/LeaderboardBackend/appsettings.Staging.json
@@ -19,8 +19,5 @@
 				"Url": "https://localhost:8080"
 			}
 		}
-	},
-	"Db": {
-		"PortVar": "POSTGRES_TEST_PORT"
 	}
 }

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ After installing a code editor:
 
 ### Running the Database(s)
 
-We use Postgres, but have the ability to run .NET's in-memory DB as well instead, which allows quicker debugging. If you would like to use the latter, you can set `USE_IN_MEMORY_DB` in your `.env` file to `true`, or not make a `.env` file at all, then skip to the next section. If you would like to use the former, follow these instructions:
+We use Postgres, but have the ability to run .NET's in-memory DB as well instead, which allows quicker debugging. If you would like to use the latter, you can set `ApplicationContext__UseInMemoryDb` in your `.env` file to `true`, or not make a `.env` file at all, then skip to the next section. If you would like to use the former, follow these instructions:
 
 As mentioned above, we run Docker containers for the DB. After [installing Docker Compose](https://docs.docker.com/compose/install/), run these commands in the project root:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,19 +6,19 @@ services:
         image: postgres
         restart: always
         environment:
-            POSTGRES_USER: ${POSTGRES_USER}
-            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-            POSTGRES_DB: ${POSTGRES_DB}
+            POSTGRES_USER: ${ApplicationContext__PG__USER}
+            POSTGRES_PASSWORD: ${ApplicationContext__PG__PASSWORD}
+            POSTGRES_DB: ${ApplicationContext__PG__DB}
         ports:
-            - ${POSTGRES_PORT}:5432
+            - ${ApplicationContext__PG__PORT}:5432
 
     db-test:
         image: postgres
         restart: always
         environment:
-            POSTGRES_USER: ${POSTGRES_USER}
-            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-            POSTGRES_DB: ${POSTGRES_DB}
+            POSTGRES_USER: ${ApplicationContext__PG__USER}
+            POSTGRES_PASSWORD: ${ApplicationContext__PG__PASSWORD}
+            POSTGRES_DB: ${ApplicationContext__PG__DB}
         ports:
             - ${POSTGRES_TEST_PORT}:5432
 

--- a/example.env
+++ b/example.env
@@ -1,12 +1,17 @@
 # copy and rename this file to '.env' to take effect
-USE_IN_MEMORY_DB=false
 
-POSTGRES_HOST=localhost
-POSTGRES_USER=admin
-POSTGRES_PASSWORD=example
-POSTGRES_DB=leaderboardsmain
+ApplicationContext__UseInMemoryDb=false
+ApplicationContext__MigrateDb=false
+ApplicationContext__PG__HOST=localhost
+ApplicationContext__PG__USER=admin
+ApplicationContext__PG__PASSWORD=example
+ApplicationContext__PG__DB=leaderboardsmain
+ApplicationContext__PG__PORT=5432
 
-POSTGRES_PORT=5432
+JWT__KEY=coolsecretkeywow
+JWT__ISSUER=leaderboards.gg
+
 POSTGRES_TEST_PORT=5433
 
 ADMINER_PORT=1337
+


### PR DESCRIPTION
Changes:
* Refactored configuration to use the Options pattern
* Added configuration for db migration (will be useful for the dev env deployment)
* Changed the dotenv nuget to add dotenv as a configuration provider (only in Development env)

## Options pattern
Going forward all new configuration should be strongly typed and validated.

The main benefit of using the [Options pattern](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options?view=aspnetcore-7.0) is configuration validation.

Note that here I've injected it as `IOptions<ConfigObject>` in services, but `ConfigObject` could also be directly injected by also adding it as a singleton:
```csharp
builder.Services.AddSingleton(services => services.GetRequiredService<IOptions<ConfigObject>>().Value);
```
Injecting as `IOptions<>` introduces a dependency on `Microsoft.Extensions.Options` in services. Let me know if you have an opinion about this.

I've removed direct env vars readings and made it rely the framework's configuration system instead.
By default ASP.NET already loads environment variables, [but with a specific format](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-7.0#naming-of-environment-variables) (see `example.env` for updated env var names)

## `POSTGRES_TEST_PORT` configuration
I plan on removing this config when I add [Testcontainers](https://dotnet.testcontainers.org/) to integration tests in a future PR. A test DB container will automatically be created and binded to a random available port.

I might have missed other configurations, let me know in that case.