### PR TITLE
Run integration tests against a Postgres container (Testcontainers)

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -13,11 +13,9 @@ jobs:
           uses: actions/setup-dotnet@v1
           with:
             dotnet-version: '7.0.x'
-        - name: Create .env file
-          run: cp example.env .env
-        - name: Spin up containers
-          run: docker compose up -d
-        - name: Run Tests on In Memory Database
-          run: ApplicationContext__UseInMemoryDb=true dotnet test LeaderboardBackend.Test
-        - name: Run Tests on Test Postgres Database
-          run: ApplicationContext__UseInMemoryDb=false dotnet test LeaderboardBackend.Test
+        - name: Restore NuGet packages 
+          run: dotnet restore
+        - name: Build
+          run: dotnet build --no-restore
+        - name: Run tests
+          run: dotnet test LeaderboardBackend.Test --no-restore

--- a/LeaderboardBackend.Jobs/LeaderboardBackend.Jobs.csproj
+++ b/LeaderboardBackend.Jobs/LeaderboardBackend.Jobs.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="../.env">
+    <None Include="../.env" Condition="Exists('../.env')">
 	  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/LeaderboardBackend.Test/Bans.cs
+++ b/LeaderboardBackend.Test/Bans.cs
@@ -23,21 +23,11 @@ internal class Bans
 	private static User s_normalUser = null!;
 
 	[OneTimeSetUp]
-	public void OneTimeSetup()
+	public async Task OneTimeSetup()
 	{
 		s_factory = new();
 		s_apiClient = s_factory.CreateTestApiClient();
-	}
 
-	[OneTimeTearDown]
-	public void OneTimeTeardown()
-	{
-		s_factory.Dispose();
-	}
-
-	[SetUp]
-	public async Task SetUp()
-	{
 		s_factory.ResetDatabase();
 
 		s_adminJwt = (await s_apiClient.LoginAdminUser()).Token;
@@ -72,6 +62,12 @@ internal class Bans
 			});
 
 		s_modJwt = (await s_apiClient.LoginUser("mod@email.com", "Passw0rd!")).Token;
+	}
+
+	[OneTimeTearDown]
+	public void OneTimeTeardown()
+	{
+		s_factory.Dispose();
 	}
 
 	[Test]

--- a/LeaderboardBackend.Test/Bans.cs
+++ b/LeaderboardBackend.Test/Bans.cs
@@ -22,11 +22,24 @@ internal class Bans
 	private static User s_modUser = null!;
 	private static User s_normalUser = null!;
 
-	[SetUp]
-	public static async Task SetUp()
+	[OneTimeSetUp]
+	public void OneTimeSetup()
 	{
-		s_factory = new TestApiFactory();
+		s_factory = new();
 		s_apiClient = s_factory.CreateTestApiClient();
+	}
+
+	[OneTimeTearDown]
+	public void OneTimeTeardown()
+	{
+		s_factory.Dispose();
+	}
+
+	[SetUp]
+	public async Task SetUp()
+	{
+		s_factory.ResetDatabase();
+
 		s_adminJwt = (await s_apiClient.LoginAdminUser()).Token;
 
 		// Set up users and leaderboard

--- a/LeaderboardBackend.Test/Categories.cs
+++ b/LeaderboardBackend.Test/Categories.cs
@@ -17,23 +17,19 @@ internal class Categories
 	private static string? s_jwt;
 
 	[OneTimeSetUp]
-	public void OneTimeSetUp()
+	public async Task OneTimeSetUp()
 	{
 		s_factory = new TestApiFactory();
 		s_apiClient = s_factory.CreateTestApiClient();
+
+		s_factory.ResetDatabase();
+		s_jwt = (await s_apiClient.LoginAdminUser()).Token;
 	}
 
 	[OneTimeTearDown]
 	public void OneTimeTearDown()
 	{
 		s_factory.Dispose();
-	}
-
-	[SetUp]
-	public async Task SetUp()
-	{
-		s_factory.ResetDatabase();
-		s_jwt = (await s_apiClient.LoginAdminUser()).Token;
 	}
 
 	[Test]

--- a/LeaderboardBackend.Test/Categories.cs
+++ b/LeaderboardBackend.Test/Categories.cs
@@ -17,10 +17,22 @@ internal class Categories
 	private static string? s_jwt;
 
 	[OneTimeSetUp]
-	public static async Task SetUp()
+	public void OneTimeSetUp()
 	{
 		s_factory = new TestApiFactory();
 		s_apiClient = s_factory.CreateTestApiClient();
+	}
+
+	[OneTimeTearDown]
+	public void OneTimeTearDown()
+	{
+		s_factory.Dispose();
+	}
+
+	[SetUp]
+	public async Task SetUp()
+	{
+		s_factory.ResetDatabase();
 		s_jwt = (await s_apiClient.LoginAdminUser()).Token;
 	}
 

--- a/LeaderboardBackend.Test/Fixtures/PostgresDatabaseFixture.cs
+++ b/LeaderboardBackend.Test/Fixtures/PostgresDatabaseFixture.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+using LeaderboardBackend.Test.Fixtures;
+using Npgsql;
+using NUnit.Framework;
+
+// Fixtures apply to all tests in its namespace
+// It has no namespace on purpose, so that the fixture applies to all tests in this assembly
+
+[SetUpFixture] // https://docs.nunit.org/articles/nunit/writing-tests/attributes/setupfixture.html
+internal class PostgresDatabaseFixture
+{
+	public static TestcontainerDatabase? PostgresContainer { get; private set; }
+	public static bool HasCreatedTemplate { get; private set; } = false;
+
+	private static string TemplateDatabase => PostgresContainer?.Database + "_template";
+
+	[OneTimeSetUp]
+	public static async Task OneTimeSetup()
+	{
+		if (TestConfig.DatabaseBackend != DatabaseBackend.TestContainer)
+		{
+			return;
+		}
+
+		PostgresContainer = new ContainerBuilder<PostgreSqlTestcontainer>()
+			.WithDatabase(new PostgreSqlTestcontainerConfiguration
+			{
+				Database = "db",
+				Username = "dbuser",
+				Password = "weft5gst768sr",
+			})
+			.WithTmpfsMount("/var/lib/postgresql/data") // db files in-memory
+			.Build();
+		await PostgresContainer.StartAsync();
+	}
+
+	[OneTimeTearDown]
+	public static async Task OneTimeTearDown()
+	{
+		if (PostgresContainer is null)
+		{
+			return;
+		}
+
+		await PostgresContainer.DisposeAsync();
+	}
+
+	public static void CreateTemplateFromCurrentDb()
+	{
+		ThrowIfNotInitialized();
+
+		NpgsqlConnection.ClearAllPools(); // can't drop a DB if connections remain open
+		using NpgsqlDataSource conn = CreateConnectionToTemplate();
+		conn.CreateCommand(@$"
+			DROP DATABASE IF EXISTS {TemplateDatabase};
+			CREATE DATABASE {TemplateDatabase}
+				WITH TEMPLATE {PostgresContainer!.Database}
+				OWNER '{PostgresContainer!.Username}';
+			")
+			.ExecuteNonQuery();
+		HasCreatedTemplate = true;
+	}
+
+
+	// It is faster to recreate the db from an already seeded template
+	// compared to dropping the db and recreating it from scratch
+	public static void ResetDatabaseToTemplate()
+	{
+		ThrowIfNotInitialized();
+		if (!HasCreatedTemplate)
+		{
+			throw new InvalidOperationException("Database template has not been created.");
+		}
+		NpgsqlConnection.ClearAllPools(); // can't drop a DB if connections remain open
+		using NpgsqlDataSource conn = CreateConnectionToTemplate();
+		conn.CreateCommand(@$"
+			DROP DATABASE IF EXISTS {PostgresContainer!.Database};
+			CREATE DATABASE {PostgresContainer!.Database}
+				WITH TEMPLATE {TemplateDatabase}
+				OWNER '{PostgresContainer!.Username}';
+			")
+			.ExecuteNonQuery();
+	}
+
+	private static NpgsqlDataSource CreateConnectionToTemplate()
+	{
+		ThrowIfNotInitialized();
+		NpgsqlConnectionStringBuilder connStrBuilder = new(PostgresContainer!.ConnectionString)
+		{
+			Database = "template1"
+		};
+		return NpgsqlDataSource.Create(connStrBuilder);
+	}
+
+	private static void ThrowIfNotInitialized()
+	{
+		if (PostgresContainer is null)
+		{
+			throw new InvalidOperationException("Postgres container is not initialized.");
+		}
+	}
+}

--- a/LeaderboardBackend.Test/Fixtures/PostgresDatabaseFixture.cs
+++ b/LeaderboardBackend.Test/Fixtures/PostgresDatabaseFixture.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Threading.Tasks;
-using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Configurations;
-using DotNet.Testcontainers.Containers;
 using LeaderboardBackend.Test.Fixtures;
 using Npgsql;
 using NUnit.Framework;
+using Testcontainers.PostgreSql;
 
 // Fixtures apply to all tests in its namespace
 // It has no namespace on purpose, so that the fixture applies to all tests in this assembly
@@ -13,10 +11,13 @@ using NUnit.Framework;
 [SetUpFixture] // https://docs.nunit.org/articles/nunit/writing-tests/attributes/setupfixture.html
 internal class PostgresDatabaseFixture
 {
-	public static TestcontainerDatabase? PostgresContainer { get; private set; }
+	public static PostgreSqlContainer? PostgresContainer { get; private set; }
+	public static string? Database { get; private set; }
+	public static string? Username { get; private set; }
+	public static string? Password { get; private set; }
+	public static int Port { get; private set; }
 	public static bool HasCreatedTemplate { get; private set; } = false;
-
-	private static string TemplateDatabase => PostgresContainer?.Database + "_template";
+	private static string TemplateDatabase => Database! + "_template";
 
 	[OneTimeSetUp]
 	public static async Task OneTimeSetup()
@@ -26,16 +27,16 @@ internal class PostgresDatabaseFixture
 			return;
 		}
 
-		PostgresContainer = new ContainerBuilder<PostgreSqlTestcontainer>()
-			.WithDatabase(new PostgreSqlTestcontainerConfiguration
-			{
-				Database = "db",
-				Username = "dbuser",
-				Password = "weft5gst768sr",
-			})
+		PostgresContainer = new PostgreSqlBuilder()
 			.WithTmpfsMount("/var/lib/postgresql/data") // db files in-memory
 			.Build();
 		await PostgresContainer.StartAsync();
+
+		NpgsqlConnectionStringBuilder connStrBuilder = new(PostgresContainer.GetConnectionString());
+		Username = connStrBuilder.Username!;
+		Password = connStrBuilder.Password!;
+		Database = connStrBuilder.Database!;
+		Port = connStrBuilder.Port;
 	}
 
 	[OneTimeTearDown]
@@ -58,8 +59,8 @@ internal class PostgresDatabaseFixture
 		conn.CreateCommand(@$"
 			DROP DATABASE IF EXISTS {TemplateDatabase};
 			CREATE DATABASE {TemplateDatabase}
-				WITH TEMPLATE {PostgresContainer!.Database}
-				OWNER '{PostgresContainer!.Username}';
+				WITH TEMPLATE {Database}
+				OWNER '{Username}';
 			")
 			.ExecuteNonQuery();
 		HasCreatedTemplate = true;
@@ -78,10 +79,10 @@ internal class PostgresDatabaseFixture
 		NpgsqlConnection.ClearAllPools(); // can't drop a DB if connections remain open
 		using NpgsqlDataSource conn = CreateConnectionToTemplate();
 		conn.CreateCommand(@$"
-			DROP DATABASE IF EXISTS {PostgresContainer!.Database};
-			CREATE DATABASE {PostgresContainer!.Database}
+			DROP DATABASE IF EXISTS {Database};
+			CREATE DATABASE {Database}
 				WITH TEMPLATE {TemplateDatabase}
-				OWNER '{PostgresContainer!.Username}';
+				OWNER '{Username}';
 			")
 			.ExecuteNonQuery();
 	}
@@ -89,7 +90,7 @@ internal class PostgresDatabaseFixture
 	private static NpgsqlDataSource CreateConnectionToTemplate()
 	{
 		ThrowIfNotInitialized();
-		NpgsqlConnectionStringBuilder connStrBuilder = new(PostgresContainer!.ConnectionString)
+		NpgsqlConnectionStringBuilder connStrBuilder = new(PostgresContainer!.GetConnectionString())
 		{
 			Database = "template1"
 		};

--- a/LeaderboardBackend.Test/Fixtures/TestConfig.cs
+++ b/LeaderboardBackend.Test/Fixtures/TestConfig.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace LeaderboardBackend.Test.Fixtures;
+
+internal static class TestConfig
+{
+	public static DatabaseBackend DatabaseBackend { get; private set; } = DatabaseBackend.TestContainer;
+
+	static TestConfig()
+	{
+		string? backendVar = Environment.GetEnvironmentVariable("INTEGRATION_TESTS_DB_BACKEND");
+		if (Enum.TryParse(backendVar, out DatabaseBackend dbBackend))
+		{
+			DatabaseBackend = dbBackend;
+		}
+	}
+}
+
+internal enum DatabaseBackend
+{
+	InMemory,
+	TestContainer,
+}

--- a/LeaderboardBackend.Test/Judgements.cs
+++ b/LeaderboardBackend.Test/Judgements.cs
@@ -25,21 +25,11 @@ internal class Judgements
 	private const string VALID_EMAIL = "test@email.com";
 
 	[OneTimeSetUp]
-	public void OneTimeSetup()
+	public async Task OneTimeSetup()
 	{
 		s_factory = new TestApiFactory();
 		s_apiClient = s_factory.CreateTestApiClient();
-	}
 
-	[OneTimeTearDown]
-	public void OneTimeTearDown()
-	{
-		s_factory.Dispose();
-	}
-
-	[SetUp]
-	public async Task SetUp()
-	{
 		s_factory.ResetDatabase();
 
 		// Set up a default Leaderboard and a mod user for that leaderboard to use as the Jwt for
@@ -87,6 +77,12 @@ internal class Judgements
 			});
 
 		s_jwt = (await s_apiClient.LoginUser(VALID_EMAIL, VALID_PASSWORD)).Token;
+	}
+
+	[OneTimeTearDown]
+	public void OneTimeTearDown()
+	{
+		s_factory.Dispose();
 	}
 
 	[Test]

--- a/LeaderboardBackend.Test/Judgements.cs
+++ b/LeaderboardBackend.Test/Judgements.cs
@@ -24,11 +24,23 @@ internal class Judgements
 	private const string VALID_PASSWORD = "c00l_pAssword";
 	private const string VALID_EMAIL = "test@email.com";
 
-	[SetUp]
-	public static async Task SetUp()
+	[OneTimeSetUp]
+	public void OneTimeSetup()
 	{
 		s_factory = new TestApiFactory();
 		s_apiClient = s_factory.CreateTestApiClient();
+	}
+
+	[OneTimeTearDown]
+	public void OneTimeTearDown()
+	{
+		s_factory.Dispose();
+	}
+
+	[SetUp]
+	public async Task SetUp()
+	{
+		s_factory.ResetDatabase();
 
 		// Set up a default Leaderboard and a mod user for that leaderboard to use as the Jwt for
 		// tests

--- a/LeaderboardBackend.Test/LeaderboardBackend.Test.csproj
+++ b/LeaderboardBackend.Test/LeaderboardBackend.Test.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="../.env">
+    <None Include="../.env" Condition="Exists('../.env')">
 	  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/LeaderboardBackend.Test/LeaderboardBackend.Test.csproj
+++ b/LeaderboardBackend.Test/LeaderboardBackend.Test.csproj
@@ -16,7 +16,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Testcontainers" Version="2.4.0" />
+    <PackageReference Include="Testcontainers" Version="3.0.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LeaderboardBackend.Test/LeaderboardBackend.Test.csproj
+++ b/LeaderboardBackend.Test/LeaderboardBackend.Test.csproj
@@ -16,6 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Testcontainers" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LeaderboardBackend.Test/Leaderboards.cs
+++ b/LeaderboardBackend.Test/Leaderboards.cs
@@ -19,11 +19,23 @@ internal class Leaderboards
 	private static TestApiFactory s_factory = null!;
 	private static string? s_jwt;
 
-	[SetUp]
-	public static async Task SetUp()
+	[OneTimeSetUp]
+	public void OneTimeSetUp()
 	{
 		s_factory = new TestApiFactory();
 		s_apiClient = s_factory.CreateTestApiClient();
+	}
+
+	[OneTimeTearDown]
+	public void OneTimeTearDown()
+	{
+		s_factory.Dispose();
+	}
+
+	[SetUp]
+	public async Task SetUp()
+	{
+		s_factory.ResetDatabase();
 		s_jwt = (await s_apiClient.LoginAdminUser()).Token;
 	}
 

--- a/LeaderboardBackend.Test/Leaderboards.cs
+++ b/LeaderboardBackend.Test/Leaderboards.cs
@@ -20,10 +20,13 @@ internal class Leaderboards
 	private static string? s_jwt;
 
 	[OneTimeSetUp]
-	public void OneTimeSetUp()
+	public async Task OneTimeSetUp()
 	{
 		s_factory = new TestApiFactory();
 		s_apiClient = s_factory.CreateTestApiClient();
+
+		s_factory.ResetDatabase();
+		s_jwt = (await s_apiClient.LoginAdminUser()).Token;
 	}
 
 	[OneTimeTearDown]
@@ -32,18 +35,11 @@ internal class Leaderboards
 		s_factory.Dispose();
 	}
 
-	[SetUp]
-	public async Task SetUp()
-	{
-		s_factory.ResetDatabase();
-		s_jwt = (await s_apiClient.LoginAdminUser()).Token;
-	}
-
 	[Test]
 	public static void GetLeaderboard_NotFound()
 	{
 		RequestFailureException e = Assert.ThrowsAsync<RequestFailureException>(async () =>
-			await s_apiClient.Get<Leaderboard>($"/api/leaderboards/2", new()))!;
+			await s_apiClient.Get<Leaderboard>($"/api/leaderboards/{long.MaxValue}", new()))!;
 
 		Assert.AreEqual(HttpStatusCode.NotFound, e.Response.StatusCode);
 	}

--- a/LeaderboardBackend.Test/Modships.cs
+++ b/LeaderboardBackend.Test/Modships.cs
@@ -19,10 +19,12 @@ internal class Modships
 	private static string s_jwt = null!;
 
 	[OneTimeSetUp]
-	public void OneTimeSetUp()
+	public async Task OneTimeSetUp()
 	{
 		s_factory = new TestApiFactory();
 		s_apiClient = s_factory.CreateTestApiClient();
+
+		s_jwt = (await s_apiClient.LoginAdminUser()).Token;
 	}
 
 	[OneTimeTearDown]
@@ -32,10 +34,9 @@ internal class Modships
 	}
 
 	[SetUp]
-	public async Task SetUp()
+	public void SetUp()
 	{
 		s_factory.ResetDatabase();
-		s_jwt = (await s_apiClient.LoginAdminUser()).Token;
 	}
 
 	[Test]

--- a/LeaderboardBackend.Test/Modships.cs
+++ b/LeaderboardBackend.Test/Modships.cs
@@ -18,11 +18,23 @@ internal class Modships
 	private static TestApiFactory s_factory = null!;
 	private static string s_jwt = null!;
 
-	[SetUp]
-	public static async Task SetUp()
+	[OneTimeSetUp]
+	public void OneTimeSetUp()
 	{
 		s_factory = new TestApiFactory();
 		s_apiClient = s_factory.CreateTestApiClient();
+	}
+
+	[OneTimeTearDown]
+	public void OneTimeTearDown()
+	{
+		s_factory.Dispose();
+	}
+
+	[SetUp]
+	public async Task SetUp()
+	{
+		s_factory.ResetDatabase();
 		s_jwt = (await s_apiClient.LoginAdminUser()).Token;
 	}
 

--- a/LeaderboardBackend.Test/Runs.cs
+++ b/LeaderboardBackend.Test/Runs.cs
@@ -19,11 +19,18 @@ namespace LeaderboardBackend.Test
 		private static string s_jwt = null!;
 		private static long s_categoryId;
 
-		[SetUp]
-		public static async Task SetUp()
+		[OneTimeSetUp]
+		public void OneTimeSetUp()
 		{
 			s_factory = new TestApiFactory();
 			s_apiClient = s_factory.CreateTestApiClient();
+		}
+
+		[SetUp]
+		public async Task SetUp()
+		{
+			s_factory.ResetDatabase();
+
 			s_jwt = (await s_apiClient.LoginAdminUser()).Token;
 
 			Leaderboard createdLeaderboard = await s_apiClient.Post<Leaderboard>(

--- a/LeaderboardBackend.Test/TestApi/TestApiFactory.cs
+++ b/LeaderboardBackend.Test/TestApi/TestApiFactory.cs
@@ -35,11 +35,11 @@ internal class TestApiFactory : WebApplicationFactory<Program>
 					conf.UseInMemoryDb = false;
 					conf.Pg = new PostgresConfig
 					{
-						Db = PostgresDatabaseFixture.PostgresContainer.Database,
-						Port = (ushort)PostgresDatabaseFixture.PostgresContainer.Port,
+						Db = PostgresDatabaseFixture.Database!,
+						Port = (ushort)PostgresDatabaseFixture.Port,
 						Host = PostgresDatabaseFixture.PostgresContainer.Hostname,
-						User = PostgresDatabaseFixture.PostgresContainer.Username,
-						Password = PostgresDatabaseFixture.PostgresContainer.Password
+						User = PostgresDatabaseFixture.Username!,
+						Password = PostgresDatabaseFixture.Password!
 					};
 				});
 			}

--- a/LeaderboardBackend.Test/Users.cs
+++ b/LeaderboardBackend.Test/Users.cs
@@ -19,11 +19,23 @@ internal class Users
 	private const string VALID_PASSWORD = "c00l_pAssword";
 	private const string VALID_EMAIL = "test@email.com";
 
-	[SetUp]
-	public static void SetUp()
+	[OneTimeSetUp]
+	public void OneTimeSetUp()
 	{
 		s_factory = new TestApiFactory();
 		s_apiClient = s_factory.CreateTestApiClient();
+	}
+
+	[OneTimeTearDown]
+	public void OneTimeTearDown()
+	{
+		s_factory.Dispose();
+	}
+
+	[SetUp]
+	public void SetUp()
+	{
+		s_factory.ResetDatabase();
 	}
 
 	[Test]

--- a/LeaderboardBackend/LeaderboardBackend.csproj
+++ b/LeaderboardBackend/LeaderboardBackend.csproj
@@ -38,7 +38,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Include="../.env">
+		<None Include="../.env" Condition="Exists('../.env')">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
 	</ItemGroup>

--- a/LeaderboardBackend/Program.cs
+++ b/LeaderboardBackend/Program.cs
@@ -180,11 +180,6 @@ using (ApplicationContext context = scope.ServiceProvider.GetRequiredService<App
 	ApplicationContextConfig config = scope.ServiceProvider
 		.GetRequiredService<IOptions<ApplicationContextConfig>>().Value;
 
-	if (config.MigrateDb)
-	{
-		context.Database.Migrate();
-	}
-
 	if (config.UseInMemoryDb)
 	{
 		// If in memory DB, the only way to have an admin user is to seed it at startup.
@@ -198,6 +193,10 @@ using (ApplicationContext context = scope.ServiceProvider.GetRequiredService<App
 
 		context.Users.Add(admin);
 		await context.SaveChangesAsync();
+	}
+	else if (config.MigrateDb)
+	{
+		context.Database.Migrate();
 	}
 }
 

--- a/README.md
+++ b/README.md
@@ -65,31 +65,43 @@ After installing a code editor:
 
 ## Running the Application
 
-### Running the Database(s)
+The application reads configuration from environment variables, a `.env` file, and a `appsettings.json` file.
 
-We use Postgres, but have the ability to run .NET's in-memory DB as well instead, which allows quicker debugging. If you would like to use the latter, you can set `ApplicationContext__UseInMemoryDb` in your `.env` file to `true`, or not make a `.env` file at all, then skip to the next section. If you would like to use the former, follow these instructions:
-
-As mentioned above, we run Docker containers for the DB. After [installing Docker Compose](https://docs.docker.com/compose/install/), run these commands in the project root:
-
+The easiest is to make a `.env` file. As a starting point, you can copy the template file `example.env` at the project root and rename it to `.env`.
 ```bash
 cp example.env .env
-sudo docker-compose (or docker compose) up -d
 ```
+
+### Running the Database(s)
+We use Postgres, but have the ability to run Entity Framework's in-memory DB as well instead, which allows quicker debugging.
+
+**Running with Postgres is highly encouraged**, as the in-memory DB will not behave the same as Postgres,
+and [some features will not work at all](https://learn.microsoft.com/en-us/ef/core/testing/choosing-a-testing-strategy#in-memory-as-a-database-fake) (for example: transactions and constraints).
+
+#### Postgres with Docker compose
+As mentioned above, we run Docker containers for the DB. After [installing Docker Compose](https://docs.docker.com/compose/install/), run this command in the project root:
+
+```bash
+docker compose up -d
+```
+If you're using Linux, you might need to run Docker with `sudo`.
 
 This starts up:
 - Adminer which is a GUI manager for the databases
-- The main Postgres DB
-- The test Postgres DB
+- A Postgres DB
 
-Using the default values provided in `example.env`, input these values in Adminer for access:
+If you're using the default values provided in `example.env`, input these values in Adminer for access:
 
-| Field | Value |
-| --- | --- |
-| System | PostgreSQL |
-| Server | db (for main) / db-test (for test) |
-| Username | admin |
-| Password | example |
-| Database | leaderboardsmain / leaderboardstest |
+| Field    | Value              | Comment
+| -------- | ------------------ | -------
+| System   | PostgreSQL         |
+| Server   | `db`               | You cannot set it to `localhost` because it must match the Docker container name
+| Username | `admin`            | Corresponds to the `ApplicationContext__PG__USER` config
+| Password | `example`          | Corresponds to `ApplicationContext__PG__PASSWORD`
+| Database | `leaderboardsmain` | Corresponds to `ApplicationContext__PG__DB`
+
+#### In-memory database
+To use the in-memory database, set `ApplicationContext__UseInMemoryDb` in your `.env` file to `true`.
 
 ### Visual Studio
 
@@ -145,8 +157,8 @@ dotnet run --project LeaderboardBackend --urls https://localhost:7128 // dotnet 
 The value provided to `--urls` has to match what's listed under `applicationUrl` in `LeaderboardBackend/Properties/launchSettings.json`. As of this writing, it's `https://localhost:7128`.
 
 #### Test the App
-Docker is required to run integration tests against a real database.  
-However, if you would like to run the tests with an in-memory database, you can set the following environment variable: `INTEGRATION_TESTS_DB_BACKEND=InMemory`.
+Docker is required to run integration tests against a real Postgres database.  
+However, if you would still like to run the tests with an in-memory database, you can set the following environment variable: `INTEGRATION_TESTS_DB_BACKEND=InMemory`.
 
 To run the tests, run the following commands from the root of the project:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repo is a proof-of-concept for switching to a C# with ASP.NET Core stack. T
 
 * JSON REST API intended for the leaderboards.gg site
 * C# with ASP.NET Core, .NET 7
-* Docker containers for PostgreSQL hosting and management run via [Docker Compose](https://docs.docker.com/compose/install/)
+* Docker containers for PostgreSQL hosting and management run via [Docker Compose](https://docs.docker.com/compose/install/), and also for integration tests with [Testcontainers](https://dotnet.testcontainers.org/)
 
 # Project Setup
 
@@ -145,6 +145,8 @@ dotnet run --project LeaderboardBackend --urls https://localhost:7128 // dotnet 
 The value provided to `--urls` has to match what's listed under `applicationUrl` in `LeaderboardBackend/Properties/launchSettings.json`. As of this writing, it's `https://localhost:7128`.
 
 #### Test the App
+Docker is required to run integration tests against a real database.  
+However, if you would like to run the tests with an in-memory database, you can set the following environment variable: `INTEGRATION_TESTS_DB_BACKEND=InMemory`.
 
 To run the tests, run the following commands from the root of the project:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,16 +12,6 @@ services:
         ports:
             - ${ApplicationContext__PG__PORT}:5432
 
-    db-test:
-        image: postgres
-        restart: always
-        environment:
-            POSTGRES_USER: ${ApplicationContext__PG__USER}
-            POSTGRES_PASSWORD: ${ApplicationContext__PG__PASSWORD}
-            POSTGRES_DB: ${ApplicationContext__PG__DB}
-        ports:
-            - ${POSTGRES_TEST_PORT}:5432
-
     adminer:
         image: adminer
         restart: always

--- a/example.env
+++ b/example.env
@@ -11,7 +11,5 @@ ApplicationContext__PG__PORT=5432
 JWT__KEY=coolsecretkeywow
 JWT__ISSUER=leaderboards.gg
 
-POSTGRES_TEST_PORT=5433
-
 ADMINER_PORT=1337
 


### PR DESCRIPTION
## Motivation
Integration tests against an in-memory db are not reliable: some SQL requests can work perfectly against the in-memory db and fail on the real database. This PR aims to make running the tests against a real database very simple (no more docker-compose).
## Changes summary
- Changed the README to mention the Docker dependency and how to run in-memory tests

### Test project:
- Made tests run against a temporary Postgres Docker container via the [Testcontainers library](https://dotnet.testcontainers.org/)
  - The container is created only once and automatically deleted at the end.
  - The database is reset by dropping the db and recreating it from an already seeded template DB.
- Changed the setup of some test classes to run only once for faster execution time.

### CI/build changes:
- Removed db-test from docker-compose because it is replaced by Testcontainers (and its associated `POSTGRES_TEST_PORT` env variable from `example.env`
- Made .env file completely optional (.csproj edits), and removed the step that creates it in the CI.
- Separated nuget restore, build, and test steps on the CI so it is easier to see where failure occurs.
- Removed in-memory tests (it's still possible to run them with this env variable: `INTEGRATION_TESTS_DB_BACKEND=InMemory`)


### New dependencies:
- [Testcontainers](https://dotnet.testcontainers.org/)
- Docker

## Performance
I've made resetting the database as fast as I could, but keep in mind resetting the db is slow, and often easily avoidable.

API requests in `[SetUp]` also take a lot of time if there are a lot of tests in the class, so they should be kept to a minimum as well.