### PR TITLE
Get leaderboard by slug + add Leaderboard and Category view models

### DIFF
--- a/LeaderboardBackend.Test/Categories.cs
+++ b/LeaderboardBackend.Test/Categories.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Threading.Tasks;
-using LeaderboardBackend.Models.Entities;
 using LeaderboardBackend.Models.Requests;
+using LeaderboardBackend.Models.ViewModels;
 using LeaderboardBackend.Test.Lib;
 using LeaderboardBackend.Test.TestApi;
 using LeaderboardBackend.Test.TestApi.Extensions;
@@ -36,7 +36,7 @@ internal class Categories
 	public static void GetCategory_Unauthorized()
 	{
 		RequestFailureException e = Assert.ThrowsAsync<RequestFailureException>(async () =>
-			await s_apiClient.Get<Category>($"/api/categories/1", new()))!;
+			await s_apiClient.Get<CategoryViewModel>($"/api/categories/1", new()))!;
 
 		Assert.AreEqual(HttpStatusCode.Unauthorized, e.Response.StatusCode);
 	}
@@ -45,7 +45,7 @@ internal class Categories
 	public static void GetCategory_NotFound()
 	{
 		RequestFailureException e = Assert.ThrowsAsync<RequestFailureException>(async () =>
-			await s_apiClient.Get<Category>($"/api/categories/69", new() { Jwt = s_jwt }))!;
+			await s_apiClient.Get<CategoryViewModel>($"/api/categories/69", new() { Jwt = s_jwt }))!;
 
 		Assert.AreEqual(HttpStatusCode.NotFound, e.Response.StatusCode);
 	}
@@ -53,7 +53,7 @@ internal class Categories
 	[Test]
 	public static async Task CreateCategory_GetCategory_OK()
 	{
-		Leaderboard createdLeaderboard = await s_apiClient.Post<Leaderboard>(
+		LeaderboardViewModel createdLeaderboard = await s_apiClient.Post<LeaderboardViewModel>(
 			"/api/leaderboards",
 			new()
 			{
@@ -65,7 +65,7 @@ internal class Categories
 				Jwt = s_jwt
 			});
 
-		Category createdCategory = await s_apiClient.Post<Category>(
+		CategoryViewModel createdCategory = await s_apiClient.Post<CategoryViewModel>(
 			"/api/categories",
 			new()
 			{
@@ -80,7 +80,7 @@ internal class Categories
 
 		Assert.AreEqual(1, createdCategory.PlayersMax);
 
-		Category retrievedCategory = await s_apiClient.Get<Category>(
+		CategoryViewModel retrievedCategory = await s_apiClient.Get<CategoryViewModel>(
 			$"/api/categories/{createdCategory?.Id}",
 			new() { Jwt = s_jwt });
 

--- a/LeaderboardBackend.Test/Fixtures/TestConfig.cs
+++ b/LeaderboardBackend.Test/Fixtures/TestConfig.cs
@@ -13,6 +13,8 @@ internal static class TestConfig
 		{
 			DatabaseBackend = dbBackend;
 		}
+
+        Bogus.Randomizer.Seed = new Random(43817269); // fixed seed for repeatable tests
 	}
 }
 

--- a/LeaderboardBackend.Test/GlobalUsings.cs
+++ b/LeaderboardBackend.Test/GlobalUsings.cs
@@ -1,0 +1,4 @@
+global using AutoBogus;
+global using Bogus;
+global using FluentAssertions;
+

--- a/LeaderboardBackend.Test/LeaderboardBackend.Test.csproj
+++ b/LeaderboardBackend.Test/LeaderboardBackend.Test.csproj
@@ -8,6 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoBogus" Version="2.13.1" />
+    <PackageReference Include="Bogus" Version="34.0.2" />
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/LeaderboardBackend.Test/LeaderboardBackend.Test.csproj
+++ b/LeaderboardBackend.Test/LeaderboardBackend.Test.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <None Include="../.env" Condition="Exists('../.env')">
-	  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/LeaderboardBackend.Test/Leaderboards.cs
+++ b/LeaderboardBackend.Test/Leaderboards.cs
@@ -8,7 +8,6 @@ using LeaderboardBackend.Models.ViewModels;
 using LeaderboardBackend.Test.TestApi;
 using LeaderboardBackend.Test.TestApi.Extensions;
 using NUnit.Framework;
-using NUnit.Framework.Constraints;
 
 namespace LeaderboardBackend.Test;
 
@@ -118,12 +117,11 @@ internal class Leaderboards
 				});
 		}
 
-		List<LeaderboardViewModel> leaderboards = await s_apiClient.Get<List<LeaderboardViewModel>>(
-			$"api/leaderboards?slug={createReqBody.Slug}",
+		LeaderboardViewModel leaderboard = await s_apiClient.Get<LeaderboardViewModel>(
+			$"api/leaderboards/{createReqBody.Slug}",
 			new());
 
-		leaderboards.Should().HaveCount(1);
-		leaderboards.Single().Should().BeEquivalentTo(createdLeaderboard);
+		leaderboard.Should().BeEquivalentTo(createdLeaderboard);
 	}
 
 	[Test]
@@ -142,11 +140,11 @@ internal class Leaderboards
 		}
 
 		CreateLeaderboardRequest reqForInexistentBoard = _createBoardReqFaker.Generate();
-		List<LeaderboardViewModel> leaderboards = await s_apiClient.Get<List<LeaderboardViewModel>>(
-			$"api/leaderboards?slug={reqForInexistentBoard.Slug}",
-			new());
 
-		leaderboards.Should().BeEmpty();
+		RequestFailureException e = Assert.ThrowsAsync<RequestFailureException>(() =>
+			s_apiClient.Get<string>($"/api/leaderboards/{reqForInexistentBoard.Slug}", new()))!;
+
+		e.Response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 	}
 
 	private static string ListToQueryString<T>(IEnumerable<T> list, string key)

--- a/LeaderboardBackend.Test/Leaderboards.cs
+++ b/LeaderboardBackend.Test/Leaderboards.cs
@@ -1,10 +1,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
-using LeaderboardBackend.Models.Entities;
 using LeaderboardBackend.Models.Requests;
+using LeaderboardBackend.Models.ViewModels;
 using LeaderboardBackend.Test.Lib;
 using LeaderboardBackend.Test.TestApi;
 using LeaderboardBackend.Test.TestApi.Extensions;
@@ -39,7 +38,7 @@ internal class Leaderboards
 	public static void GetLeaderboard_NotFound()
 	{
 		RequestFailureException e = Assert.ThrowsAsync<RequestFailureException>(async () =>
-			await s_apiClient.Get<Leaderboard>($"/api/leaderboards/{long.MaxValue}", new()))!;
+			await s_apiClient.Get<LeaderboardViewModel>($"/api/leaderboards/{long.MaxValue}", new()))!;
 
 		Assert.AreEqual(HttpStatusCode.NotFound, e.Response.StatusCode);
 	}
@@ -47,7 +46,7 @@ internal class Leaderboards
 	[Test]
 	public static async Task CreateLeaderboard_GetLeaderboard_OK()
 	{
-		Leaderboard createdLeaderboard = await s_apiClient.Post<Leaderboard>(
+		LeaderboardViewModel createdLeaderboard = await s_apiClient.Post<LeaderboardViewModel>(
 			"/api/leaderboards",
 			new()
 			{
@@ -59,7 +58,7 @@ internal class Leaderboards
 				Jwt = s_jwt
 			});
 
-		Leaderboard retrievedLeaderboard = await s_apiClient.Get<Leaderboard>(
+		LeaderboardViewModel retrievedLeaderboard = await s_apiClient.Get<LeaderboardViewModel>(
 			$"/api/leaderboards/{createdLeaderboard?.Id}",
 			new());
 
@@ -69,12 +68,12 @@ internal class Leaderboards
 	[Test]
 	public static async Task CreateLeaderboards_GetLeaderboards()
 	{
-		HashSet<Leaderboard> createdLeaderboards = new();
+		HashSet<LeaderboardViewModel> createdLeaderboards = new();
 
 		for (int i = 0; i < 5; i++)
 		{
 			createdLeaderboards.Add(
-				await s_apiClient.Post<Leaderboard>(
+				await s_apiClient.Post<LeaderboardViewModel>(
 					"/api/leaderboards",
 					new()
 					{
@@ -90,11 +89,11 @@ internal class Leaderboards
 		IEnumerable<long> leaderboardIds = createdLeaderboards.Select(l => l.Id).ToList();
 		string leaderboardIdQuery = ListToQueryString(leaderboardIds, "ids");
 
-		List<Leaderboard> leaderboards = await s_apiClient.Get<List<Leaderboard>>(
+		List<LeaderboardViewModel> leaderboards = await s_apiClient.Get<List<LeaderboardViewModel>>(
 			$"api/leaderboards?{leaderboardIdQuery}",
 			new());
 
-		foreach (Leaderboard leaderboard in leaderboards)
+		foreach (LeaderboardViewModel leaderboard in leaderboards)
 		{
 			Assert.IsTrue(createdLeaderboards.Contains(leaderboard));
 			createdLeaderboards.Remove(leaderboard);

--- a/LeaderboardBackend.Test/Leaderboards.cs
+++ b/LeaderboardBackend.Test/Leaderboards.cs
@@ -1,13 +1,14 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using LeaderboardBackend.Models.Requests;
 using LeaderboardBackend.Models.ViewModels;
-using LeaderboardBackend.Test.Lib;
 using LeaderboardBackend.Test.TestApi;
 using LeaderboardBackend.Test.TestApi.Extensions;
 using NUnit.Framework;
+using NUnit.Framework.Constraints;
 
 namespace LeaderboardBackend.Test;
 
@@ -17,6 +18,9 @@ internal class Leaderboards
 	private static TestApiClient s_apiClient = null!;
 	private static TestApiFactory s_factory = null!;
 	private static string? s_jwt;
+
+	private readonly Faker<CreateLeaderboardRequest> _createBoardReqFaker = new AutoFaker<CreateLeaderboardRequest>()
+		.RuleFor(x => x.Slug, b => string.Join('-', b.Lorem.Words(2)));
 
 	[OneTimeSetUp]
 	public async Task OneTimeSetUp()
@@ -35,7 +39,7 @@ internal class Leaderboards
 	}
 
 	[Test]
-	public static void GetLeaderboard_NotFound()
+	public void GetLeaderboard_NotFound()
 	{
 		RequestFailureException e = Assert.ThrowsAsync<RequestFailureException>(async () =>
 			await s_apiClient.Get<LeaderboardViewModel>($"/api/leaderboards/{long.MaxValue}", new()))!;
@@ -44,17 +48,14 @@ internal class Leaderboards
 	}
 
 	[Test]
-	public static async Task CreateLeaderboard_GetLeaderboard_OK()
+	public async Task CreateLeaderboard_GetLeaderboard_OK()
 	{
+		CreateLeaderboardRequest req = _createBoardReqFaker.Generate();
 		LeaderboardViewModel createdLeaderboard = await s_apiClient.Post<LeaderboardViewModel>(
 			"/api/leaderboards",
 			new()
 			{
-				Body = new CreateLeaderboardRequest
-				{
-					Name = Generators.GenerateRandomString(),
-					Slug = Generators.GenerateRandomString()
-				},
+				Body = req,
 				Jwt = s_jwt
 			});
 
@@ -62,29 +63,26 @@ internal class Leaderboards
 			$"/api/leaderboards/{createdLeaderboard?.Id}",
 			new());
 
-		Assert.AreEqual(createdLeaderboard, retrievedLeaderboard);
+		createdLeaderboard.Should().NotBeNull();
+		(string, string) expectedCreatedBoard = ValueTuple.Create(req.Name, req.Slug);
+		(string, string) actualCreatedBoard = ValueTuple.Create(createdLeaderboard!.Name, createdLeaderboard.Slug);
+		expectedCreatedBoard.Should().BeEquivalentTo(actualCreatedBoard);
+
+		createdLeaderboard.Should().BeEquivalentTo(retrievedLeaderboard);
 	}
 
 	[Test]
-	public static async Task CreateLeaderboards_GetLeaderboards()
+	public async Task CreateLeaderboards_GetLeaderboards()
 	{
-		HashSet<LeaderboardViewModel> createdLeaderboards = new();
-
-		for (int i = 0; i < 5; i++)
-		{
-			createdLeaderboards.Add(
-				await s_apiClient.Post<LeaderboardViewModel>(
-					"/api/leaderboards",
-					new()
-					{
-						Body = new CreateLeaderboardRequest
-						{
-							Name = Generators.GenerateRandomString(),
-							Slug = Generators.GenerateRandomString()
-						},
-						Jwt = s_jwt
-					}));
-		}
+		IEnumerable<Task<LeaderboardViewModel>> boardCreationTasks = _createBoardReqFaker.GenerateBetween(3, 10)
+			.Select(req => s_apiClient.Post<LeaderboardViewModel>(
+				"/api/leaderboards",
+				new()
+				{
+					Body = req,
+					Jwt = s_jwt
+				}));
+		LeaderboardViewModel[] createdLeaderboards = await Task.WhenAll(boardCreationTasks);
 
 		IEnumerable<long> leaderboardIds = createdLeaderboards.Select(l => l.Id).ToList();
 		string leaderboardIdQuery = ListToQueryString(leaderboardIds, "ids");
@@ -93,13 +91,62 @@ internal class Leaderboards
 			$"api/leaderboards?{leaderboardIdQuery}",
 			new());
 
-		foreach (LeaderboardViewModel leaderboard in leaderboards)
+		leaderboards.Should().BeEquivalentTo(createdLeaderboards);
+	}
+
+	[Test]
+	public async Task GetLeaderboards_BySlug_OK()
+	{
+		CreateLeaderboardRequest createReqBody = _createBoardReqFaker.Generate();
+		LeaderboardViewModel createdLeaderboard = await s_apiClient.Post<LeaderboardViewModel>(
+			"/api/leaderboards",
+			new()
+			{
+				Body = createReqBody,
+				Jwt = s_jwt
+			});
+
+		// create random unrelated boards
+		foreach (CreateLeaderboardRequest req in _createBoardReqFaker.Generate(2))
 		{
-			Assert.IsTrue(createdLeaderboards.Contains(leaderboard));
-			createdLeaderboards.Remove(leaderboard);
+			await s_apiClient.Post<LeaderboardViewModel>(
+				"/api/leaderboards",
+				new()
+				{
+					Body = req,
+					Jwt = s_jwt
+				});
 		}
 
-		Assert.AreEqual(0, createdLeaderboards.Count);
+		List<LeaderboardViewModel> leaderboards = await s_apiClient.Get<List<LeaderboardViewModel>>(
+			$"api/leaderboards?slug={createReqBody.Slug}",
+			new());
+
+		leaderboards.Should().HaveCount(1);
+		leaderboards.Single().Should().BeEquivalentTo(createdLeaderboard);
+	}
+
+	[Test]
+	public async Task GetLeaderboards_BySlug_NotFound()
+	{
+		// populate with unrelated boards
+		foreach (CreateLeaderboardRequest req in _createBoardReqFaker.Generate(2))
+		{
+			await s_apiClient.Post<LeaderboardViewModel>(
+				"/api/leaderboards",
+				new()
+				{
+					Body = req,
+					Jwt = s_jwt
+				});
+		}
+
+		CreateLeaderboardRequest reqForInexistentBoard = _createBoardReqFaker.Generate();
+		List<LeaderboardViewModel> leaderboards = await s_apiClient.Get<List<LeaderboardViewModel>>(
+			$"api/leaderboards?slug={reqForInexistentBoard.Slug}",
+			new());
+
+		leaderboards.Should().BeEmpty();
 	}
 
 	private static string ListToQueryString<T>(IEnumerable<T> list, string key)

--- a/LeaderboardBackend/Controllers/CategoriesController.cs
+++ b/LeaderboardBackend/Controllers/CategoriesController.cs
@@ -1,6 +1,7 @@
 using LeaderboardBackend.Controllers.Annotations;
 using LeaderboardBackend.Models.Entities;
 using LeaderboardBackend.Models.Requests;
+using LeaderboardBackend.Models.ViewModels;
 using LeaderboardBackend.Services;
 using Microsoft.AspNetCore.Mvc;
 
@@ -26,7 +27,7 @@ public class CategoriesController : ControllerBase
 	/// <response code="404">No `Category` with the requested ID could be found.</response>
 	[ApiConventionMethod(typeof(Conventions), nameof(Conventions.Get))]
 	[HttpGet("{id}")]
-	public async Task<ActionResult<Category>> GetCategory(long id)
+	public async Task<ActionResult<CategoryViewModel>> GetCategory(long id)
 	{
 		// NOTE: Should this use [AllowAnonymous]? - Ero
 
@@ -37,7 +38,7 @@ public class CategoriesController : ControllerBase
 			return NotFound();
 		}
 
-		return Ok(category);
+		return Ok(CategoryViewModel.MapFrom(category));
 	}
 
 	/// <summary>
@@ -54,7 +55,7 @@ public class CategoriesController : ControllerBase
 	/// </response>
 	[ApiConventionMethod(typeof(Conventions), nameof(Conventions.Post))]
 	[HttpPost]
-	public async Task<ActionResult<Category>> CreateCategory(
+	public async Task<ActionResult<CategoryViewModel>> CreateCategory(
 		[FromBody] CreateCategoryRequest request)
 	{
 		// FIXME: Allow only moderators to call this! - Ero
@@ -73,6 +74,6 @@ public class CategoriesController : ControllerBase
 
 		await _categoryService.CreateCategory(category);
 
-		return CreatedAtAction(nameof(GetCategory), new { id = category.Id }, category);
+		return CreatedAtAction(nameof(GetCategory), new { id = category.Id }, CategoryViewModel.MapFrom(category));
 	}
 }

--- a/LeaderboardBackend/Controllers/LeaderboardsController.cs
+++ b/LeaderboardBackend/Controllers/LeaderboardsController.cs
@@ -2,6 +2,7 @@ using LeaderboardBackend.Authorization;
 using LeaderboardBackend.Controllers.Annotations;
 using LeaderboardBackend.Models.Entities;
 using LeaderboardBackend.Models.Requests;
+using LeaderboardBackend.Models.ViewModels;
 using LeaderboardBackend.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -28,7 +29,7 @@ public class LeaderboardsController : ControllerBase
 	[AllowAnonymous]
 	[ApiConventionMethod(typeof(Conventions), nameof(Conventions.GetAnon))]
 	[HttpGet("{id}")]
-	public async Task<ActionResult<Leaderboard>> GetLeaderboard(long id)
+	public async Task<ActionResult<LeaderboardViewModel>> GetLeaderboard(long id)
 	{
 		Leaderboard? leaderboard = await _leaderboardService.GetLeaderboard(id);
 
@@ -37,7 +38,7 @@ public class LeaderboardsController : ControllerBase
 			return NotFound();
 		}
 
-		return Ok(leaderboard);
+		return Ok(LeaderboardViewModel.MapFrom(leaderboard));
 	}
 
 	/// <summary>
@@ -51,10 +52,11 @@ public class LeaderboardsController : ControllerBase
 	[AllowAnonymous]
 	[HttpGet]
 	[ProducesResponseType(StatusCodes.Status200OK)]
-	public async Task<ActionResult<List<Leaderboard>>> GetLeaderboards(
+	public async Task<ActionResult<List<LeaderboardViewModel>>> GetLeaderboards(
 		[FromQuery] long[] ids)
 	{
-		return Ok(await _leaderboardService.GetLeaderboards(ids));
+		List<Leaderboard> result = await _leaderboardService.GetLeaderboards(ids);
+		return Ok(result.Select(LeaderboardViewModel.MapFrom));
 	}
 
 	/// <summary>
@@ -72,7 +74,7 @@ public class LeaderboardsController : ControllerBase
 	[ApiConventionMethod(typeof(Conventions), nameof(Conventions.Post))]
 	[Authorize(Policy = UserTypes.ADMINISTRATOR)]
 	[HttpPost]
-	public async Task<ActionResult<Leaderboard>> CreateLeaderboard(
+	public async Task<ActionResult<LeaderboardViewModel>> CreateLeaderboard(
 		[FromBody] CreateLeaderboardRequest request)
 	{
 		Leaderboard leaderboard = new()
@@ -83,6 +85,6 @@ public class LeaderboardsController : ControllerBase
 
 		await _leaderboardService.CreateLeaderboard(leaderboard);
 
-		return CreatedAtAction(nameof(GetLeaderboard), new { id = leaderboard.Id }, leaderboard);
+		return CreatedAtAction(nameof(GetLeaderboard), new { id = leaderboard.Id }, LeaderboardViewModel.MapFrom(leaderboard));
 	}
 }

--- a/LeaderboardBackend/Controllers/LeaderboardsController.cs
+++ b/LeaderboardBackend/Controllers/LeaderboardsController.cs
@@ -45,6 +45,7 @@ public class LeaderboardsController : ControllerBase
 	///     Gets Leaderboards by their IDs.
 	/// </summary>
 	/// <param name="ids">The IDs of the `Leaderboard`s which should be retrieved.</param>
+	/// <param name="slug">The slug of the `Leaderboard` to retrieve</param>
 	/// <response code="200">
 	///     The list of `Leaderboard`s was retrieved successfully. The result can be an empty
 	///     collection.
@@ -53,9 +54,10 @@ public class LeaderboardsController : ControllerBase
 	[HttpGet]
 	[ProducesResponseType(StatusCodes.Status200OK)]
 	public async Task<ActionResult<List<LeaderboardViewModel>>> GetLeaderboards(
-		[FromQuery] long[] ids)
+		[FromQuery] long[] ids, [FromQuery] string? slug = null)
 	{
-		List<Leaderboard> result = await _leaderboardService.GetLeaderboards(ids);
+		GetLeaderboardsQuery query = new(ids, slug);
+		List<Leaderboard> result = await _leaderboardService.GetLeaderboards(query);
 		return Ok(result.Select(LeaderboardViewModel.MapFrom));
 	}
 

--- a/LeaderboardBackend/Controllers/LeaderboardsController.cs
+++ b/LeaderboardBackend/Controllers/LeaderboardsController.cs
@@ -25,10 +25,10 @@ public class LeaderboardsController : ControllerBase
 	/// </summary>
 	/// <param name="id">The ID of the `Leaderboard` which should be retrieved.</param>
 	/// <response code="200">The `Leaderboard` was found and returned successfully.</response>
-	/// <response code="404">No `Leaderboard` with the requested ID could be found.</response>
+	/// <response code="404">No `Leaderboard` with the requested ID or slug could be found.</response>
 	[AllowAnonymous]
 	[ApiConventionMethod(typeof(Conventions), nameof(Conventions.GetAnon))]
-	[HttpGet("{id}")]
+	[HttpGet("{id:long}")]
 	public async Task<ActionResult<LeaderboardViewModel>> GetLeaderboard(long id)
 	{
 		Leaderboard? leaderboard = await _leaderboardService.GetLeaderboard(id);
@@ -42,10 +42,30 @@ public class LeaderboardsController : ControllerBase
 	}
 
 	/// <summary>
+	///     Gets a Leaderboard by its slug.
+	/// </summary>
+	/// <param name="slug">The slug of the `Leaderboard` which should be retrieved.</param>
+	/// <response code="200">The `Leaderboard` was found and returned successfully.</response>
+	/// <response code="404">No `Leaderboard` with the requested ID or slug could be found.</response>
+	[AllowAnonymous]
+	[ApiConventionMethod(typeof(Conventions), nameof(Conventions.GetAnon))]
+	[HttpGet("{slug}")]
+	public async Task<ActionResult<LeaderboardViewModel>> GetLeaderboardBySlug(string slug)
+	{
+		Leaderboard? leaderboard = await _leaderboardService.GetLeaderboardBySlug(slug);
+
+		if (leaderboard == null)
+		{
+			return NotFound();
+		}
+
+		return Ok(LeaderboardViewModel.MapFrom(leaderboard));
+	}
+
+	/// <summary>
 	///     Gets Leaderboards by their IDs.
 	/// </summary>
 	/// <param name="ids">The IDs of the `Leaderboard`s which should be retrieved.</param>
-	/// <param name="slug">The slug of the `Leaderboard` to retrieve</param>
 	/// <response code="200">
 	///     The list of `Leaderboard`s was retrieved successfully. The result can be an empty
 	///     collection.
@@ -54,10 +74,9 @@ public class LeaderboardsController : ControllerBase
 	[HttpGet]
 	[ProducesResponseType(StatusCodes.Status200OK)]
 	public async Task<ActionResult<List<LeaderboardViewModel>>> GetLeaderboards(
-		[FromQuery] long[] ids, [FromQuery] string? slug = null)
+		[FromQuery] long[] ids)
 	{
-		GetLeaderboardsQuery query = new(ids, slug);
-		List<Leaderboard> result = await _leaderboardService.GetLeaderboards(query);
+		List<Leaderboard> result = await _leaderboardService.GetLeaderboards(ids);
 		return Ok(result.Select(LeaderboardViewModel.MapFrom));
 	}
 

--- a/LeaderboardBackend/Models/Entities/Leaderboard.cs
+++ b/LeaderboardBackend/Models/Entities/Leaderboard.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
 
 namespace LeaderboardBackend.Models.Entities;
 
@@ -38,19 +37,16 @@ public class Leaderboard
 	/// <summary>
 	///     A collection of `Category` entities for the `Leaderboard`.
 	/// </summary>
-	[JsonIgnore]
 	public List<Category>? Categories { get; set; }
 
 	/// <summary>
 	///     A collection of *Moderator*s (`Users`) for the `Leaderboard`.
 	/// </summary>
-	[JsonIgnore]
 	public List<Modship>? Modships { get; set; }
 
 	/// <summary>
 	///     A collection of `Ban`s scoped to the `Leaderboard`.
 	/// </summary>
-	[JsonIgnore]
 	public List<Ban>? Bans { get; set; }
 
 	public override bool Equals(object? obj)

--- a/LeaderboardBackend/Models/Entities/Modship.cs
+++ b/LeaderboardBackend/Models/Entities/Modship.cs
@@ -34,6 +34,7 @@ public class Modship
 	/// <summary>
 	///     Relationship model for `LeaderboardId`.
 	/// </summary>
+	[JsonIgnore] // TODO: remove JsonIgnore attribute when adding the Modship viewmodel
 	public Leaderboard? Leaderboard { get; set; } = null!;
 
 	public override bool Equals(object? obj)

--- a/LeaderboardBackend/Models/ViewModels/CategoryViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/CategoryViewModel.cs
@@ -1,0 +1,55 @@
+using LeaderboardBackend.Models.Entities;
+
+namespace LeaderboardBackend.Models.ViewModels;
+
+/// <summary>
+///     Represents a `Category` tied to a `Leaderboard`.
+/// </summary>
+public record CategoryViewModel
+{
+	/// <summary>
+	///     The unique identifier of the `Category`.<br/>
+	/// </summary>
+	public required long Id { get; set; }
+
+	/// <summary>
+	///     The display name of the `Category`.
+	/// </summary>
+	/// <example>Foo Bar Baz%</example>
+	public required string Name { get; set; }
+
+	/// <summary>
+	///     The URL-scoped unique identifier of the `Category`.<br/>
+	/// </summary>
+	/// <example>foo-bar-baz</example>
+	public required string Slug { get; set; }
+
+	/// <summary>
+	///     The rules of the `Category`.
+	/// </summary>
+	/// <example>Video proof is required.</example>
+	public required string? Rules { get; set; }
+
+	/// <summary>
+	///     The minimum player count of the `Category`. The default is 1.
+	/// </summary>
+	public required int PlayersMin { get; set; }
+
+	/// <summary>
+	///     The maximum player count of the `Category`. The default is `PlayersMin`.
+	/// </summary>
+	public required int PlayersMax { get; set; }
+
+	public static CategoryViewModel MapFrom(Category category)
+	{
+		return new CategoryViewModel
+		{
+			Id = category.Id,
+			Name = category.Name,
+			Slug = category.Slug,
+			Rules = category.Rules,
+			PlayersMin = category.PlayersMin,
+			PlayersMax = category.PlayersMax,
+		};
+	}
+}

--- a/LeaderboardBackend/Models/ViewModels/LeaderboardViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/LeaderboardViewModel.cs
@@ -1,0 +1,54 @@
+using LeaderboardBackend.Models.Entities;
+
+namespace LeaderboardBackend.Models.ViewModels;
+
+/// <summary>
+///     Represents a collection of `Category` entities.
+/// </summary>
+public record LeaderboardViewModel
+{
+	/// <summary>
+	///     The unique identifier of the `Leaderboard`.<br/>
+	///     Generated on creation.
+	/// </summary>
+	public required long Id { get; set; }
+
+	/// <summary>
+	///     The display name of the `Leaderboard` to create.
+	/// </summary>
+	/// <example>Foo Bar</example>
+	public required string Name { get; init; }
+
+	/// <summary>
+	///     The URL-scoped unique identifier of the `Leaderboard`.<br/>
+	///     Must be [2, 80] in length and consist only of alphanumeric characters and hyphens.
+	/// </summary>
+	/// <example>foo-bar</example>
+	public required string Slug { get; init; }
+
+	/// <summary>
+	///     The general rules for the Leaderboard.
+	/// </summary>
+	/// <example>Timer starts on selecting New Game and ends when the final boss is beaten.</example>
+	public required string? Rules { get; init; }
+
+	/// <summary>
+	///     A collection of `Category` entities for the `Leaderboard`.
+	/// </summary>
+	public required IList<CategoryViewModel> Categories { get; init; }
+
+	public static LeaderboardViewModel MapFrom(Leaderboard leaderboard)
+	{
+		IList<CategoryViewModel>? categories = leaderboard.Categories?
+			.Select(CategoryViewModel.MapFrom)
+			.ToList();
+		return new LeaderboardViewModel
+		{
+			Id = leaderboard.Id,
+			Name = leaderboard.Name,
+			Slug = leaderboard.Slug,
+			Rules = leaderboard.Rules,
+			Categories = categories ?? Array.Empty<CategoryViewModel>(),
+		};
+	}
+}

--- a/LeaderboardBackend/Program.cs
+++ b/LeaderboardBackend/Program.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
 using Npgsql;
 using BCryptNet = BCrypt.Net.BCrypt;
 
@@ -134,6 +135,30 @@ builder.Services.AddSwaggerGen(c =>
 	// Enable adding XML comments to controllers to populate Swagger UI
 	string xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
 	c.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));
+
+	c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+	{
+		In = ParameterLocation.Header,
+		Description = "JWT Authorization using the Bearer scheme",
+		Name = "Authorization",
+		Type = SecuritySchemeType.Http,
+		BearerFormat = "JWT",
+		Scheme = JwtBearerDefaults.AuthenticationScheme
+	});
+	c.AddSecurityRequirement(new OpenApiSecurityRequirement
+	{
+		{
+			new OpenApiSecurityScheme
+			{
+				Reference = new OpenApiReference
+				{
+					Type = ReferenceType.SecurityScheme,
+					Id = JwtBearerDefaults.AuthenticationScheme
+				}
+			},
+			Array.Empty<string>()
+		}
+	});
 });
 
 // Configure JWT Authentication.

--- a/LeaderboardBackend/Services/ILeaderboardService.cs
+++ b/LeaderboardBackend/Services/ILeaderboardService.cs
@@ -5,8 +5,7 @@ namespace LeaderboardBackend.Services;
 public interface ILeaderboardService
 {
 	Task<Leaderboard?> GetLeaderboard(long id);
-	Task<List<Leaderboard>> GetLeaderboards(GetLeaderboardsQuery query);
+	Task<Leaderboard?> GetLeaderboardBySlug(string slug);
+	Task<List<Leaderboard>> GetLeaderboards(long[]? ids = null);
 	Task CreateLeaderboard(Leaderboard leaderboard);
 }
-
-public record GetLeaderboardsQuery(long[]? Ids = null, string? Slug = null);

--- a/LeaderboardBackend/Services/ILeaderboardService.cs
+++ b/LeaderboardBackend/Services/ILeaderboardService.cs
@@ -5,6 +5,8 @@ namespace LeaderboardBackend.Services;
 public interface ILeaderboardService
 {
 	Task<Leaderboard?> GetLeaderboard(long id);
-	Task<List<Leaderboard>> GetLeaderboards(long[]? ids = null);
+	Task<List<Leaderboard>> GetLeaderboards(GetLeaderboardsQuery query);
 	Task CreateLeaderboard(Leaderboard leaderboard);
 }
+
+public record GetLeaderboardsQuery(long[]? Ids = null, string? Slug = null);

--- a/LeaderboardBackend/Services/Impl/LeaderboardService.cs
+++ b/LeaderboardBackend/Services/Impl/LeaderboardService.cs
@@ -18,22 +18,26 @@ public class LeaderboardService : ILeaderboardService
 			.FindAsync(id);
 	}
 
-	// FIXME: Paginate this
-	public async Task<List<Leaderboard>> GetLeaderboards(GetLeaderboardsQuery query)
+	public Task<Leaderboard?> GetLeaderboardBySlug(string slug)
 	{
-		IQueryable<Leaderboard> queryable = _applicationContext.Leaderboards.AsNoTracking();
+		return _applicationContext.Leaderboards.AsNoTracking()
+			.FirstOrDefaultAsync(x => x.Slug == slug);
+	}
 
-		if (query.Ids is not null && query.Ids.Length > 0)
+	// FIXME: Paginate this
+	public async Task<List<Leaderboard>> GetLeaderboards(long[]? ids = null)
+	{
+		if (ids is null)
 		{
-			queryable = queryable.Where(leaderboard => query.Ids.Contains(leaderboard.Id));
+			return await _applicationContext.Leaderboards
+				.ToListAsync();
 		}
-
-		if (query.Slug is not null)
+		else
 		{
-			queryable = queryable.Where(leaderboard => leaderboard.Slug == query.Slug);
+			return await _applicationContext.Leaderboards
+				.Where(leaderboard => ids.Contains(leaderboard.Id))
+				.ToListAsync();
 		}
-
-		return await queryable.ToListAsync();
 	}
 
 	public async Task CreateLeaderboard(Leaderboard leaderboard)

--- a/LeaderboardBackend/Services/Impl/LeaderboardService.cs
+++ b/LeaderboardBackend/Services/Impl/LeaderboardService.cs
@@ -19,19 +19,21 @@ public class LeaderboardService : ILeaderboardService
 	}
 
 	// FIXME: Paginate this
-	public async Task<List<Leaderboard>> GetLeaderboards(long[]? ids = null)
+	public async Task<List<Leaderboard>> GetLeaderboards(GetLeaderboardsQuery query)
 	{
-		if (ids is null)
+		IQueryable<Leaderboard> queryable = _applicationContext.Leaderboards.AsNoTracking();
+
+		if (query.Ids is not null && query.Ids.Length > 0)
 		{
-			return await _applicationContext.Leaderboards
-				.ToListAsync();
+			queryable = queryable.Where(leaderboard => query.Ids.Contains(leaderboard.Id));
 		}
-		else
+
+		if (query.Slug is not null)
 		{
-			return await _applicationContext.Leaderboards
-				.Where(leaderboard => ids.Contains(leaderboard.Id))
-				.ToListAsync();
+			queryable = queryable.Where(leaderboard => leaderboard.Slug == query.Slug);
 		}
+
+		return await queryable.ToListAsync();
 	}
 
 	public async Task CreateLeaderboard(Leaderboard leaderboard)

--- a/LeaderboardBackend/openapi.json
+++ b/LeaderboardBackend/openapi.json
@@ -854,6 +854,14 @@
                 "format": "int64"
               }
             }
+          },
+          {
+            "name": "slug",
+            "in": "query",
+            "description": "The slug of the `Leaderboard` to retrieve",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/LeaderboardBackend/openapi.json
+++ b/LeaderboardBackend/openapi.json
@@ -509,7 +509,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Category"
+                  "$ref": "#/components/schemas/CategoryViewModel"
                 }
               }
             }
@@ -589,7 +589,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Category"
+                  "$ref": "#/components/schemas/CategoryViewModel"
                 }
               }
             }
@@ -793,12 +793,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Leaderboard"
+                  "$ref": "#/components/schemas/LeaderboardViewModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Leaderboard"
+                  "$ref": "#/components/schemas/LeaderboardViewModel"
                 }
               }
             }
@@ -864,7 +864,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Leaderboard"
+                    "$ref": "#/components/schemas/LeaderboardViewModel"
                   }
                 }
               },
@@ -872,7 +872,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Leaderboard"
+                    "$ref": "#/components/schemas/LeaderboardViewModel"
                   }
                 }
               }
@@ -911,12 +911,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Leaderboard"
+                  "$ref": "#/components/schemas/LeaderboardViewModel"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Leaderboard"
+                  "$ref": "#/components/schemas/LeaderboardViewModel"
                 }
               }
             }
@@ -2297,6 +2297,46 @@
         "additionalProperties": false,
         "description": "Represents a `Category` tied to a `Leaderboard`."
       },
+      "CategoryViewModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The unique identifier of the `Category`.<br />",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string",
+            "description": "The display name of the `Category`.",
+            "nullable": true,
+            "example": "Foo Bar Baz%"
+          },
+          "slug": {
+            "type": "string",
+            "description": "The URL-scoped unique identifier of the `Category`.<br />",
+            "nullable": true,
+            "example": "foo-bar-baz"
+          },
+          "rules": {
+            "type": "string",
+            "description": "The rules of the `Category`.",
+            "nullable": true,
+            "example": "Video proof is required."
+          },
+          "playersMin": {
+            "type": "integer",
+            "description": "The minimum player count of the `Category`. The default is 1.",
+            "format": "int32"
+          },
+          "playersMax": {
+            "type": "integer",
+            "description": "The maximum player count of the `Category`. The default is `PlayersMin`.",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents a `Category` tied to a `Leaderboard`."
+      },
       "CreateCategoryRequest": {
         "required": [
           "leaderboardId",
@@ -2641,11 +2681,7 @@
         "additionalProperties": false,
         "description": "Represents a decision made by a *Moderator* (`User`) about a `Run`.<br />\r\nSee: LeaderboardBackend.Models.Entities.Judgement."
       },
-      "Leaderboard": {
-        "required": [
-          "name",
-          "slug"
-        ],
+      "LeaderboardViewModel": {
         "type": "object",
         "properties": {
           "id": {
@@ -2654,15 +2690,15 @@
             "format": "int64"
           },
           "name": {
-            "minLength": 1,
             "type": "string",
             "description": "The display name of the `Leaderboard` to create.",
+            "nullable": true,
             "example": "Foo Bar"
           },
           "slug": {
-            "minLength": 1,
             "type": "string",
             "description": "The URL-scoped unique identifier of the `Leaderboard`.<br />\r\nMust be [2, 80] in length and consist only of alphanumeric characters and hyphens.",
+            "nullable": true,
             "example": "foo-bar"
           },
           "rules": {
@@ -2670,6 +2706,14 @@
             "description": "The general rules for the Leaderboard.",
             "nullable": true,
             "example": "Timer starts on selecting New Game and ends when the final boss is beaten."
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CategoryViewModel"
+            },
+            "description": "A collection of `Category` entities for the `Leaderboard`.",
+            "nullable": true
           }
         },
         "additionalProperties": false,
@@ -2775,9 +2819,6 @@
             "type": "integer",
             "description": "The ID of the `Leaderboard` the `User` is a *Moderator* for.",
             "format": "int64"
-          },
-          "leaderboard": {
-            "$ref": "#/components/schemas/Leaderboard"
           }
         },
         "additionalProperties": false,

--- a/LeaderboardBackend/openapi.json
+++ b/LeaderboardBackend/openapi.json
@@ -819,7 +819,73 @@
             }
           },
           "404": {
-            "description": "No `Leaderboard` with the requested ID could be found.",
+            "description": "No `Leaderboard` with the requested ID or slug could be found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Leaderboards/{slug}": {
+      "get": {
+        "tags": [
+          "Leaderboards"
+        ],
+        "summary": "Gets a Leaderboard by its slug.",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "description": "The slug of the `Leaderboard` which should be retrieved.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The `Leaderboard` was found and returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeaderboardViewModel"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeaderboardViewModel"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No `Leaderboard` with the requested ID or slug could be found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -853,14 +919,6 @@
                 "type": "integer",
                 "format": "int64"
               }
-            }
-          },
-          {
-            "name": "slug",
-            "in": "query",
-            "description": "The slug of the `Leaderboard` to retrieve",
-            "schema": {
-              "type": "string"
             }
           }
         ],
@@ -3115,6 +3173,19 @@
         "additionalProperties": false,
         "description": "Represents a user account registered on the website."
       }
+    },
+    "securitySchemes": {
+      "Bearer": {
+        "type": "http",
+        "description": "JWT Authorization using the Bearer scheme",
+        "scheme": "Bearer",
+        "bearerFormat": "JWT"
+      }
     }
-  }
+  },
+  "security": [
+    {
+      "Bearer": [ ]
+    }
+  ]
 }


### PR DESCRIPTION
Closes #136

## Changes summary
- Added view models for `Leaderboard` and `Category`
- Added a way to get a leaderboard by its slug `GET /api/leaderboards/{slug}`
- Refactored the leaderboard tests with Bogus and FluentAssertions
- Added Bearer auth to the OpenAPI spec (also adds it to Swagger UI)

## Notes
I broke the current [ViewModel guideline](https://github.com/leaderboardsgg/leaderboard-backend/wiki/Style-Guide#viewmodels) to show what I think would be better (this wasn't possible before the project was upgraded to .NET 7):
- Each property should be `required`
- A ViewModel should have a static `MapFrom(TDomainEntity entity)` method.
  The `required` keyword ensures every property has been mapped. It doesn't work inside the constructor though so it needs to be a method.



