### PR TITLE
Allow Non-nullable Reference Types in OpenAPI Doc

### DIFF
--- a/LeaderboardBackend/AppConfig.cs
+++ b/LeaderboardBackend/AppConfig.cs
@@ -7,7 +7,10 @@ public class AppConfig
 	public string? EnvPath { get; set; } = ".env";
 	public string AllowedOrigins { get; set; } = string.Empty;
 
-	public string[] ParseAllowedOrigins() => AllowedOrigins?.Split(';') ?? Array.Empty<string>();
+	public string[] ParseAllowedOrigins()
+	{
+		return AllowedOrigins?.Split(';') ?? Array.Empty<string>();
+	}
 }
 
 public class AppConfigValidator : AbstractValidator<AppConfig>

--- a/LeaderboardBackend/AppConfig.cs
+++ b/LeaderboardBackend/AppConfig.cs
@@ -7,10 +7,7 @@ public class AppConfig
 	public string? EnvPath { get; set; } = ".env";
 	public string AllowedOrigins { get; set; } = string.Empty;
 
-	public string[] ParseAllowedOrigins()
-	{
-		return AllowedOrigins?.Split(';') ?? Array.Empty<string>();
-	}
+	public string[] ParseAllowedOrigins() => AllowedOrigins?.Split(';') ?? Array.Empty<string>();
 }
 
 public class AppConfigValidator : AbstractValidator<AppConfig>

--- a/LeaderboardBackend/Models/ViewModels/LeaderboardViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/LeaderboardViewModel.cs
@@ -3,7 +3,7 @@ using LeaderboardBackend.Models.Entities;
 namespace LeaderboardBackend.Models.ViewModels;
 
 /// <summary>
-///     Represents a collection of `Category` entities.
+///     Represents a collection of `Leaderboard` entities.
 /// </summary>
 public record LeaderboardViewModel
 {

--- a/LeaderboardBackend/Program.cs
+++ b/LeaderboardBackend/Program.cs
@@ -159,6 +159,8 @@ builder.Services.AddSwaggerGen(c =>
 			Array.Empty<string>()
 		}
 	});
+
+	c.SupportNonNullableReferenceTypes();
 });
 
 // Configure JWT Authentication.
@@ -261,6 +263,7 @@ using (ApplicationContext context = scope.ServiceProvider.GetRequiredService<App
 		{
 			defaultUser.Password = BCryptNet.EnhancedHashPassword(newPassword);
 		}
+
 		context.SaveChanges();
 	}
 	else if (config.MigrateDb && app.Environment.IsDevelopment())

--- a/LeaderboardBackend/openapi.json
+++ b/LeaderboardBackend/openapi.json
@@ -2282,12 +2282,10 @@
         "properties": {
           "id": {
             "type": "string",
-            "nullable": true,
             "readOnly": true
           },
           "name": {
             "type": "string",
-            "nullable": true,
             "readOnly": true
           },
           "minYear": {
@@ -2305,7 +2303,6 @@
             "items": {
               "$ref": "#/components/schemas/Era"
             },
-            "nullable": true,
             "readOnly": true
           }
         },
@@ -2374,13 +2371,11 @@
           "name": {
             "type": "string",
             "description": "The display name of the `Category`.",
-            "nullable": true,
             "example": "Foo Bar Baz%"
           },
           "slug": {
             "type": "string",
             "description": "The URL-scoped unique identifier of the `Category`.<br />",
-            "nullable": true,
             "example": "foo-bar-baz"
           },
           "rules": {
@@ -2465,7 +2460,6 @@
           "note": {
             "type": "string",
             "description": "A comment elaborating on the `Judgement`'s decision. Must have a value when the\r\naffected `Run` is not approved (`Approved` is null or false).",
-            "nullable": true,
             "example": "The video proof is not of sufficient quality."
           },
           "approved": {
@@ -2511,13 +2505,11 @@
           "name": {
             "type": "string",
             "description": "The display name of the `Leaderboard` to create.",
-            "nullable": true,
             "example": "Foo Bar"
           },
           "slug": {
             "type": "string",
             "description": "The URL-scoped unique identifier of the `Leaderboard`.<br />\r\nMust be [2, 80] in length and consist only of alphanumeric characters and hyphens.",
-            "nullable": true,
             "example": "foo-bar"
           }
         },
@@ -2635,7 +2627,6 @@
         "properties": {
           "name": {
             "type": "string",
-            "nullable": true,
             "readOnly": true
           }
         },
@@ -2758,13 +2749,11 @@
           "name": {
             "type": "string",
             "description": "The display name of the `Leaderboard` to create.",
-            "nullable": true,
             "example": "Foo Bar"
           },
           "slug": {
             "type": "string",
             "description": "The URL-scoped unique identifier of the `Leaderboard`.<br />\r\nMust be [2, 80] in length and consist only of alphanumeric characters and hyphens.",
-            "nullable": true,
             "example": "foo-bar"
           },
           "rules": {
@@ -2778,12 +2767,11 @@
             "items": {
               "$ref": "#/components/schemas/CategoryViewModel"
             },
-            "description": "A collection of `Category` entities for the `Leaderboard`.",
-            "nullable": true
+            "description": "A collection of `Category` entities for the `Leaderboard`."
           }
         },
         "additionalProperties": false,
-        "description": "Represents a collection of `Category` entities."
+        "description": "Represents a collection of `Leaderboard` entities."
       },
       "LocalDate": {
         "type": "object",
@@ -3091,8 +3079,7 @@
         "properties": {
           "comment": {
             "type": "string",
-            "description": "A comment about the `Participation`.",
-            "nullable": true
+            "description": "A comment about the `Participation`."
           },
           "vod": {
             "minLength": 1,


### PR DESCRIPTION
Prevents Swashbuckle from generating the OpenAPI doc with fields marked as nullable, when we didn't explicitly mark them as such in our code.

Produces, for example:
![output](https://user-images.githubusercontent.com/9867871/235313222-2e43a82e-e50a-4746-9596-fe780b24b4f2.png)