### PR TITLE
tests: ensure database initialization before OneTimeSetup of IntegrationTestsBase children runs

### DIFF
--- a/LeaderboardBackend.Test/Fixtures/IntegrationTestsBase.cs
+++ b/LeaderboardBackend.Test/Fixtures/IntegrationTestsBase.cs
@@ -8,7 +8,13 @@ public abstract class IntegrationTestsBase
 {
     protected HttpClient Client { get; private set; } = null!;
 
-    protected readonly static TestApiFactory s_factory = new();
+    protected static readonly TestApiFactory s_factory = new();
+
+    [OneTimeSetUp]
+    public void OneTimeSetup()
+    {
+        s_factory.InitializeDatabase();
+    }
 
     [SetUp]
     public void SetUp()

--- a/LeaderboardBackend.Test/LeaderboardBackend.Test.csproj
+++ b/LeaderboardBackend.Test/LeaderboardBackend.Test.csproj
@@ -24,8 +24,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Testcontainers" Version="3.2.0" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="3.2.0" />
+    <PackageReference Include="Testcontainers" Version="3.4.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="3.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes an issue where the testcontainers database is sometimes not yet initialized in OneTimeSetup methods of `IntegrationTestsBase` children. (noticed this issue with #169)

Also upgraded the testcontainers package since a new version has bugfixes for Docker detection. (@zysim had trouble with this)