### PR TITLE
Enable Swagger Doc to Be Accesible on Production

### DIFF
--- a/LeaderboardBackend/Program.cs
+++ b/LeaderboardBackend/Program.cs
@@ -282,11 +282,8 @@ builder.Services.AddSingleton<IAuthorizationMiddlewareResultHandler, MiddlewareR
 WebApplication app = builder.Build();
 
 // Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "LeaderboardBackend v1"));
-}
+app.UseSwagger();
+app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "LeaderboardBackend v1"));
 
 // Database creation / migration
 using (IServiceScope scope = app.Services.CreateScope())


### PR DESCRIPTION
Allows the doc to be viewable in the Fly.dev page, as it uses our Prd env.

Bear in mind; `UseSwaggerUI()` enables ASP.NET's [static file middleware](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/static-files?view=aspnetcore-7.0), as detailed in [this chapter in the Swashbuckle page](https://learn.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle?view=aspnetcore-7.0&tabs=visual-studio-code#add-and-configure-swagger-middleware). Shouldn't be a problem, but just bear in mind to never put sensitive data in `wwwroot`, if we even create one in our project in the first place.