### PR TITLE
Use Brevo Rest API

### DIFF
--- a/LeaderboardBackend.Test/Features/Emails/EmailSenderTests.cs
+++ b/LeaderboardBackend.Test/Features/Emails/EmailSenderTests.cs
@@ -13,6 +13,8 @@ using NUnit.Framework;
 
 namespace LeaderboardBackend.Test.Features.Emails;
 
+[Obsolete("EmailSender is no longer used.")]
+[Ignore("EmailSender is no longer used.")]
 public class EmailSenderTests
 {
     private IEmailSender _sut = null!;

--- a/LeaderboardBackend.Test/TestApi/TestApiFactory.cs
+++ b/LeaderboardBackend.Test/TestApi/TestApiFactory.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Net.Http;
 using LeaderboardBackend.Models.Entities;
+using LeaderboardBackend.Services;
 using LeaderboardBackend.Test.Lib;
-using MailKit.Net.Smtp;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
@@ -41,8 +41,7 @@ public class TestApiFactory : WebApplicationFactory<Program>
                 };
             });
 
-            // mock SMTP client
-            services.Replace(ServiceDescriptor.Transient<ISmtpClient>(_ => new Mock<ISmtpClient>().Object));
+            services.Replace(ServiceDescriptor.Singleton(_ => new Mock<IEmailSender>().Object));
 
             using IServiceScope scope = services.BuildServiceProvider().CreateScope();
             ApplicationContext dbContext =

--- a/LeaderboardBackend/LeaderboardBackend.csproj
+++ b/LeaderboardBackend/LeaderboardBackend.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+    <PackageReference Include="brevo_csharp" Version="1.0.0" />
     <PackageReference Include="DotNetEnv" Version="3.0.0" />
     <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
     <PackageReference Include="FluentValidation" Version="11.9.2" />

--- a/LeaderboardBackend/Program.cs
+++ b/LeaderboardBackend/Program.cs
@@ -48,8 +48,8 @@ builder.Services
     .ValidateOnStart();
 
 builder.Services
-    .AddOptions<EmailSenderConfig>()
-    .BindConfiguration(EmailSenderConfig.KEY)
+    .AddOptions<BrevoOptions>()
+    .BindConfiguration(BrevoOptions.KEY)
     .ValidateFluentValidation()
     .ValidateOnStart();
 
@@ -104,8 +104,7 @@ builder.Services.AddScoped<ICategoryService, CategoryService>();
 builder.Services.AddScoped<IAccountConfirmationService, AccountConfirmationService>();
 builder.Services.AddScoped<IAccountRecoveryService, AccountRecoveryService>();
 builder.Services.AddScoped<IRunService, RunService>();
-builder.Services.AddSingleton<IEmailSender, EmailSender>();
-builder.Services.AddSingleton<ISmtpClient>(_ => new SmtpClient() { Timeout = 3000 });
+builder.Services.AddSingleton<IEmailSender, BrevoService>();
 builder.Services.AddSingleton<IClock>(_ => SystemClock.Instance);
 
 AppConfig? appConfig = builder.Configuration.Get<AppConfig>();
@@ -277,6 +276,9 @@ builder.Services.AddFeatureManagement(builder.Configuration.GetSection("Feature"
 
 #region WebApplication
 WebApplication app = builder.Build();
+
+BrevoOptions brevoOptions = app.Services.GetRequiredService<IOptionsMonitor<BrevoOptions>>().CurrentValue;
+brevo_csharp.Client.Configuration.Default.AddApiKey("api-key", brevoOptions.ApiKey);
 
 // Configure the HTTP request pipeline.
 app.UseSwagger();

--- a/LeaderboardBackend/Services/Impl/BrevoOptions.cs
+++ b/LeaderboardBackend/Services/Impl/BrevoOptions.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+
+namespace LeaderboardBackend.Services;
+
+public class BrevoOptions
+{
+    public const string KEY = "Brevo";
+    public string ApiKey { get; set; } = string.Empty;
+    public required string SenderName { get; set; }
+    public required string SenderEmail { get; set; }
+}
+
+public class BrevoOptionsValidator : AbstractValidator<BrevoOptions>
+{
+    public BrevoOptionsValidator()
+    {
+        RuleFor(x => x.SenderName).NotEmpty();
+        RuleFor(x => x.SenderEmail).EmailAddress();
+    }
+}

--- a/LeaderboardBackend/Services/Impl/BrevoService.cs
+++ b/LeaderboardBackend/Services/Impl/BrevoService.cs
@@ -1,0 +1,18 @@
+using brevo_csharp.Api;
+using brevo_csharp.Model;
+using Microsoft.Extensions.Options;
+
+namespace LeaderboardBackend.Services;
+
+public class BrevoService(IOptions<BrevoOptions> options, ILogger<BrevoService> logger) : IEmailSender
+{
+    private readonly TransactionalEmailsApi _transactionalEmailsApi = new();
+    private readonly SendSmtpEmailSender _smtpEmailSender = new(options.Value.SenderName, options.Value.SenderEmail);
+
+    public async System.Threading.Tasks.Task EnqueueEmailAsync(string recipientAddress, string subject, string htmlMessage)
+    {
+        SendSmtpEmail email = new(_smtpEmailSender, [new(recipientAddress)], null, null, htmlMessage, null, subject);
+        CreateSmtpEmail result = await _transactionalEmailsApi.SendTransacEmailAsync(email);
+        logger.LogInformation("Email sent with id {Id}", result.MessageId);
+    }
+}

--- a/LeaderboardBackend/Services/Impl/EmailSender.cs
+++ b/LeaderboardBackend/Services/Impl/EmailSender.cs
@@ -4,6 +4,7 @@ using MimeKit;
 
 namespace LeaderboardBackend.Services;
 
+[Obsolete("Replaced by BrevoService")]
 public class EmailSender : IEmailSender
 {
     private readonly EmailSenderConfig _config;

--- a/LeaderboardBackend/appsettings.json
+++ b/LeaderboardBackend/appsettings.json
@@ -7,9 +7,9 @@
 	},
 	"EnvPath": ".env",
 	"AllowedHosts": "*",
-	"EmailSender": {
+	"Brevo": {
 		"SenderName": "Leaderboards.gg",
-		"SenderAddress": "no-reply@leaderboards.gg"
+		"SenderEmail": "no-reply@leaderboards.gg"
 	},
   "Feature": {
     "AccountRecovery": true,

--- a/example.env
+++ b/example.env
@@ -14,9 +14,6 @@ ApplicationContext__PG__PORT=5432
 JWT__KEY=coolsecretkeywowitssoincredibleiloveit
 JWT__ISSUER=leaderboards.gg
 
-EmailSender__Smtp__Host=smtp-relay.sendinblue.com
-EmailSender__Smtp__Port=587
-EmailSender__Smtp__Username=User42
-EmailSender__Smtp__Password=Password123
-
 ADMINER_PORT=1337
+
+Brevo__ApiKey=my-brevo-api-key


### PR DESCRIPTION
This PR deprecates the `EmailSender` service and replaces it with `BrevoService` which uses Brevo's REST API to send emails instead of an SMTP relay. Closes #208.