### PR TITLE
Adds DB volume to docker compose db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -397,3 +397,6 @@ FodyWeavers.xsd
 *.env
 !example.env
 !swagger-gen.env
+
+# Github Codespaces
+.devcontainer/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
             POSTGRES_USER: ${ApplicationContext__PG__USER}
             POSTGRES_PASSWORD: ${ApplicationContext__PG__PASSWORD}
             POSTGRES_DB: ${ApplicationContext__PG__DB}
+        volumes:
+            - 'db_data:/var/lib/postgresql/data'
         ports:
             - ${ApplicationContext__PG__PORT}:5432
 
@@ -17,3 +19,5 @@ services:
         restart: always
         ports:
             - ${ADMINER_PORT}:8080
+volumes:
+  db_data:


### PR DESCRIPTION
Under the current docker compose setup - no database changes are saved if a container gets shut down. 

Adding a volume lets the database persist between compose runs when you choose not to use the daemon.

This also adds a .devcontainer gitignore for codespace configuration.