### PR TITLE
List Leaderboards Endpoint

### DIFF
--- a/LeaderboardBackend/Controllers/LeaderboardsController.cs
+++ b/LeaderboardBackend/Controllers/LeaderboardsController.cs
@@ -50,11 +50,12 @@ public class LeaderboardsController(ILeaderboardService leaderboardService) : Ap
     [HttpGet("api/leaderboards")]
     [SwaggerOperation("Gets leaderboards by their IDs.", OperationId = "getLeaderboards")]
     [SwaggerResponse(200)]
-    public async Task<ActionResult<List<LeaderboardViewModel>>> GetLeaderboards(
-        [FromQuery] long[] ids
-    )
+    public async Task<ActionResult<List<LeaderboardViewModel>>> GetLeaderboards([FromQuery] long[] ids)
     {
-        List<Leaderboard> result = await leaderboardService.GetLeaderboards(ids);
+        List<Leaderboard> result = Request.Query.ContainsKey("ids") ?
+            await leaderboardService.GetLeaderboardsById(ids) :
+            await leaderboardService.ListLeaderboards();
+
         return Ok(result.Select(LeaderboardViewModel.MapFrom));
     }
 

--- a/LeaderboardBackend/Controllers/LeaderboardsController.cs
+++ b/LeaderboardBackend/Controllers/LeaderboardsController.cs
@@ -48,14 +48,13 @@ public class LeaderboardsController(ILeaderboardService leaderboardService) : Ap
 
     [AllowAnonymous]
     [HttpGet("api/leaderboards")]
-    [SwaggerOperation("Gets leaderboards by their IDs.", OperationId = "getLeaderboards")]
+    [SwaggerOperation("Gets all leaderboards.", OperationId = "listLeaderboards")]
     [SwaggerResponse(200)]
-    public async Task<ActionResult<List<LeaderboardViewModel>>> GetLeaderboards([FromQuery] long[] ids)
+    public async Task<ActionResult<List<LeaderboardViewModel>>> GetLeaderboards()
     {
-        List<Leaderboard> result = Request.Query.ContainsKey("ids") ?
-            await leaderboardService.GetLeaderboardsById(ids) :
-            await leaderboardService.ListLeaderboards();
+        // TODO: Paginate.
 
+        List<Leaderboard> result = await leaderboardService.ListLeaderboards();
         return Ok(result.Select(LeaderboardViewModel.MapFrom));
     }
 

--- a/LeaderboardBackend/Models/ViewModels/LeaderboardViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/LeaderboardViewModel.cs
@@ -54,14 +54,14 @@ public record LeaderboardViewModel
     /// <summary>
     ///     A collection of `Category` entities for the `Leaderboard`.
     /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public IList<CategoryViewModel> Categories { get; init; }
+    public required IList<CategoryViewModel> Categories { get; init; }
 
     public static LeaderboardViewModel MapFrom(Leaderboard leaderboard)
     {
         IList<CategoryViewModel> categories = leaderboard.Categories
             ?.Select(CategoryViewModel.MapFrom)
             .ToList();
+
         return new LeaderboardViewModel
         {
             Id = leaderboard.Id,
@@ -71,7 +71,7 @@ public record LeaderboardViewModel
             CreatedAt = leaderboard.CreatedAt,
             UpdatedAt = leaderboard.UpdatedAt,
             DeletedAt = leaderboard.DeletedAt,
-            Categories = categories,
+            Categories = categories ?? Array.Empty<CategoryViewModel>(),
         };
     }
 }

--- a/LeaderboardBackend/Models/ViewModels/LeaderboardViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/LeaderboardViewModel.cs
@@ -1,4 +1,3 @@
-using System.Text.Json.Serialization;
 using LeaderboardBackend.Models.Entities;
 using NodaTime;
 

--- a/LeaderboardBackend/Models/ViewModels/LeaderboardViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/LeaderboardViewModel.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using LeaderboardBackend.Models.Entities;
 using NodaTime;
 
@@ -51,7 +52,8 @@ public record LeaderboardViewModel
     /// <summary>
     ///     A collection of `Category` entities for the `Leaderboard`.
     /// </summary>
-    public required IList<CategoryViewModel> Categories { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IList<CategoryViewModel>? Categories { get; init; }
 
     public static LeaderboardViewModel MapFrom(Leaderboard leaderboard)
     {
@@ -67,7 +69,7 @@ public record LeaderboardViewModel
             CreatedAt = leaderboard.CreatedAt,
             UpdatedAt = leaderboard.UpdatedAt,
             DeletedAt = leaderboard.DeletedAt,
-            Categories = categories ?? Array.Empty<CategoryViewModel>(),
+            Categories = categories,
         };
     }
 }

--- a/LeaderboardBackend/Models/ViewModels/LeaderboardViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/LeaderboardViewModel.cs
@@ -4,8 +4,6 @@ using NodaTime;
 
 namespace LeaderboardBackend.Models.ViewModels;
 
-#nullable disable warnings
-
 /// <summary>
 ///     Represents a collection of `Leaderboard` entities.
 /// </summary>
@@ -58,7 +56,7 @@ public record LeaderboardViewModel
 
     public static LeaderboardViewModel MapFrom(Leaderboard leaderboard)
     {
-        IList<CategoryViewModel> categories = leaderboard.Categories
+        IList<CategoryViewModel>? categories = leaderboard.Categories
             ?.Select(CategoryViewModel.MapFrom)
             .ToList();
 

--- a/LeaderboardBackend/Models/ViewModels/LeaderboardViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/LeaderboardViewModel.cs
@@ -4,6 +4,8 @@ using NodaTime;
 
 namespace LeaderboardBackend.Models.ViewModels;
 
+#nullable disable warnings
+
 /// <summary>
 ///     Represents a collection of `Leaderboard` entities.
 /// </summary>
@@ -53,11 +55,11 @@ public record LeaderboardViewModel
     ///     A collection of `Category` entities for the `Leaderboard`.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public IList<CategoryViewModel>? Categories { get; init; }
+    public IList<CategoryViewModel> Categories { get; init; }
 
     public static LeaderboardViewModel MapFrom(Leaderboard leaderboard)
     {
-        IList<CategoryViewModel>? categories = leaderboard.Categories
+        IList<CategoryViewModel> categories = leaderboard.Categories
             ?.Select(CategoryViewModel.MapFrom)
             .ToList();
         return new LeaderboardViewModel

--- a/LeaderboardBackend/Services/ILeaderboardService.cs
+++ b/LeaderboardBackend/Services/ILeaderboardService.cs
@@ -9,7 +9,8 @@ public interface ILeaderboardService
 {
     Task<Leaderboard?> GetLeaderboard(long id);
     Task<Leaderboard?> GetLeaderboardBySlug(string slug);
-    Task<List<Leaderboard>> GetLeaderboards(long[]? ids = null);
+    Task<List<Leaderboard>> ListLeaderboards();
+    Task<List<Leaderboard>> GetLeaderboardsById(long[] ids);
     Task<CreateLeaderboardResult> CreateLeaderboard(CreateLeaderboardRequest request);
 }
 

--- a/LeaderboardBackend/Services/ILeaderboardService.cs
+++ b/LeaderboardBackend/Services/ILeaderboardService.cs
@@ -10,7 +10,6 @@ public interface ILeaderboardService
     Task<Leaderboard?> GetLeaderboard(long id);
     Task<Leaderboard?> GetLeaderboardBySlug(string slug);
     Task<List<Leaderboard>> ListLeaderboards();
-    Task<List<Leaderboard>> GetLeaderboardsById(long[] ids);
     Task<CreateLeaderboardResult> CreateLeaderboard(CreateLeaderboardRequest request);
 }
 

--- a/LeaderboardBackend/Services/Impl/LeaderboardService.cs
+++ b/LeaderboardBackend/Services/Impl/LeaderboardService.cs
@@ -20,11 +20,6 @@ public class LeaderboardService(ApplicationContext applicationContext) : ILeader
         await applicationContext.Leaderboards
             .Where(lb => lb.DeletedAt == null).ToListAsync();
 
-    public async Task<List<Leaderboard>> GetLeaderboardsById(long[] ids) =>
-        await applicationContext.Leaderboards
-            .Where(leaderboard => ids.Contains(leaderboard.Id))
-            .ToListAsync();
-
     public async Task<CreateLeaderboardResult> CreateLeaderboard(CreateLeaderboardRequest request)
     {
         Leaderboard lb = new()

--- a/LeaderboardBackend/Services/Impl/LeaderboardService.cs
+++ b/LeaderboardBackend/Services/Impl/LeaderboardService.cs
@@ -15,20 +15,15 @@ public class LeaderboardService(ApplicationContext applicationContext) : ILeader
         await applicationContext.Leaderboards
             .FirstOrDefaultAsync(b => b.Slug == slug && b.DeletedAt == null);
 
-    // FIXME: Paginate this
-    public async Task<List<Leaderboard>> GetLeaderboards(long[]? ids = null)
-    {
-        if (ids is null)
-        {
-            return await applicationContext.Leaderboards.ToListAsync();
-        }
-        else
-        {
-            return await applicationContext.Leaderboards
-                .Where(leaderboard => ids.Contains(leaderboard.Id))
-                .ToListAsync();
-        }
-    }
+    // FIXME: Paginate these
+    public async Task<List<Leaderboard>> ListLeaderboards() =>
+        await applicationContext.Leaderboards
+            .Where(lb => lb.DeletedAt == null).ToListAsync();
+
+    public async Task<List<Leaderboard>> GetLeaderboardsById(long[] ids) =>
+        await applicationContext.Leaderboards
+            .Where(leaderboard => ids.Contains(leaderboard.Id))
+            .ToListAsync();
 
     public async Task<CreateLeaderboardResult> CreateLeaderboard(CreateLeaderboardRequest request)
     {

--- a/LeaderboardBackend/openapi.json
+++ b/LeaderboardBackend/openapi.json
@@ -562,21 +562,8 @@
         "tags": [
           "Leaderboards"
         ],
-        "summary": "Gets leaderboards by their IDs.",
-        "operationId": "getLeaderboards",
-        "parameters": [
-          {
-            "name": "ids",
-            "in": "query",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "format": "int64"
-              }
-            }
-          }
-        ],
+        "summary": "Gets all leaderboards.",
+        "operationId": "listLeaderboards",
         "responses": {
           "400": {
             "description": "Bad Request",
@@ -1106,6 +1093,7 @@
       },
       "LeaderboardViewModel": {
         "required": [
+          "categories",
           "createdAt",
           "deletedAt",
           "id",

--- a/LeaderboardBackend/openapi.json
+++ b/LeaderboardBackend/openapi.json
@@ -1106,7 +1106,6 @@
       },
       "LeaderboardViewModel": {
         "required": [
-          "categories",
           "createdAt",
           "deletedAt",
           "id",


### PR DESCRIPTION
This PR essentially splits the get leaderboards endpoint into two. If you provide IDs, it'll return only the Leaderboards with those IDs; otherwise, it'll return all non-deleted Leaderboards. Closes #227 