### PR TITLE
Return Deleted Leaderboards

### DIFF
--- a/LeaderboardBackend/Services/Impl/LeaderboardService.cs
+++ b/LeaderboardBackend/Services/Impl/LeaderboardService.cs
@@ -18,8 +18,7 @@ public class LeaderboardService(ApplicationContext applicationContext) : ILeader
 
     // FIXME: Paginate these
     public async Task<List<Leaderboard>> ListLeaderboards() =>
-        await applicationContext.Leaderboards
-            .Where(lb => lb.DeletedAt == null).ToListAsync();
+        await applicationContext.Leaderboards.ToListAsync();
 
     public async Task<CreateLeaderboardResult> CreateLeaderboard(CreateLeaderboardRequest request)
     {


### PR DESCRIPTION
Allows deleted leaderboards to be returned, to allow https://github.com/leaderboardsgg/leaderboard-admin/pull/17 to work.