### PR TITLE
Disable int Parsing for Enums

### DIFF
--- a/LeaderboardBackend/Program.cs
+++ b/LeaderboardBackend/Program.cs
@@ -143,7 +143,7 @@ builder.Services
     {
         opt.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
         opt.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
-        opt.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        opt.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter(null, false));
         opt.JsonSerializerOptions.ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
         jsonSerializerOptions = opt.JsonSerializerOptions;
     });


### PR DESCRIPTION
This PR makes it so that enums on DTOs will not accept integer values when deserializing from JSON. Closes #267 