### PR TITLE
Add Statuses

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "swashbuckle.aspnetcore.cli": {
-      "version": "7.3.1",
+      "version": "8.1.1",
       "commands": [
         "swagger"
       ],

--- a/LeaderboardBackend.Test/Categories.cs
+++ b/LeaderboardBackend.Test/Categories.cs
@@ -101,6 +101,7 @@ internal class Categories
             CreatedAt = _clock.GetCurrentInstant(),
             UpdatedAt = null,
             DeletedAt = null,
+            Status = Status.Published
         });
     }
 
@@ -154,6 +155,7 @@ internal class Categories
             CreatedAt = _clock.GetCurrentInstant(),
             UpdatedAt = null,
             DeletedAt = null,
+            Status = Status.Published
         });
     }
 
@@ -277,7 +279,7 @@ internal class Categories
         resultSansDeleted.LimitDefault.Should().Be(64);
 
         ListView<CategoryViewModel> resultWithDeleted = await _apiClient.Get<ListView<CategoryViewModel>>(
-            $"api/leaderboard/{board.Id}/categories?includeDeleted=true",
+            $"api/leaderboard/{board.Id}/categories?status=any",
             new() { }
         );
 

--- a/LeaderboardBackend.Test/Leaderboards.cs
+++ b/LeaderboardBackend.Test/Leaderboards.cs
@@ -359,11 +359,11 @@ public class Leaderboards
         returned.Total.Should().Be(2);
         returned.LimitDefault.Should().Be(64);
 
-        ListView<LeaderboardViewModel> returned2 = await _apiClient.Get<ListView<LeaderboardViewModel>>("/api/leaderboards?includeDeleted=false&limit=1024", new());
+        ListView<LeaderboardViewModel> returned2 = await _apiClient.Get<ListView<LeaderboardViewModel>>("/api/leaderboards?status=published&limit=1024", new());
         returned2.Data.Should().BeEquivalentTo(boards.Take(2), config => config.Excluding(lb => lb.Categories));
         returned2.Total.Should().Be(2);
 
-        ListView<LeaderboardViewModel> returned3 = await _apiClient.Get<ListView<LeaderboardViewModel>>("/api/leaderboards?includeDeleted=true&limit=1024", new());
+        ListView<LeaderboardViewModel> returned3 = await _apiClient.Get<ListView<LeaderboardViewModel>>("/api/leaderboards?status=any&limit=1024", new());
         returned3.Data.Should().BeEquivalentTo(boards, config => config.Excluding(lb => lb.Categories));
         returned3.Total.Should().Be(3);
 
@@ -371,7 +371,7 @@ public class Leaderboards
         returned4.Total.Should().Be(2);
         returned4.Data.Single().Should().BeEquivalentTo(boards.OrderBy(lb => lb.Id).First(), config => config.Excluding(lb => lb.Categories));
 
-        ListView<LeaderboardViewModel> returned5 = await _apiClient.Get<ListView<LeaderboardViewModel>>("/api/leaderboards?limit=1&includeDeleted=true&offset=1", new());
+        ListView<LeaderboardViewModel> returned5 = await _apiClient.Get<ListView<LeaderboardViewModel>>("/api/leaderboards?limit=1&status=any&offset=1", new());
         returned5.Total.Should().Be(3);
         returned5.Data.Single().Should().BeEquivalentTo(boards.OrderBy(lb => lb.Id).Skip(1).First(), config => config.Excluding(lb => lb.Categories));
     }

--- a/LeaderboardBackend.Test/Runs.cs
+++ b/LeaderboardBackend.Test/Runs.cs
@@ -159,11 +159,11 @@ namespace LeaderboardBackend.Test
             returned.Data.Should().BeEquivalentTo(runs.Take(2).Select(RunViewModel.MapFrom));
             returned.Total.Should().Be(2);
 
-            ListView<TimedRunViewModel> returned2 = await _apiClient.Get<ListView<TimedRunViewModel>>($"/api/category/{_categoryId}/runs?includeDeleted=false&limit=1024", new());
+            ListView<TimedRunViewModel> returned2 = await _apiClient.Get<ListView<TimedRunViewModel>>($"/api/category/{_categoryId}/runs?status=published&limit=1024", new());
             returned2.Data.Should().BeEquivalentTo(runs.Take(2).Select(RunViewModel.MapFrom));
             returned2.Total.Should().Be(2);
 
-            ListView<TimedRunViewModel> returned3 = await _apiClient.Get<ListView<TimedRunViewModel>>($"/api/category/{_categoryId}/runs?includeDeleted=true&limit=1024", new());
+            ListView<TimedRunViewModel> returned3 = await _apiClient.Get<ListView<TimedRunViewModel>>($"/api/category/{_categoryId}/runs?status=any&limit=1024", new());
             returned3.Data.Should().BeEquivalentTo(new Run[] { runs[0], runs[2], runs[1] }.Select(RunViewModel.MapFrom), config => config.WithStrictOrdering());
             returned3.Total.Should().Be(3);
 
@@ -171,7 +171,7 @@ namespace LeaderboardBackend.Test
             returned4.Data.Single().Should().BeEquivalentTo(RunViewModel.MapFrom(runs[0]));
             returned4.Total.Should().Be(2);
 
-            ListView<TimedRunViewModel> returned5 = await _apiClient.Get<ListView<TimedRunViewModel>>($"/api/category/{_categoryId}/runs?limit=1&includeDeleted=true&offset=1", new());
+            ListView<TimedRunViewModel> returned5 = await _apiClient.Get<ListView<TimedRunViewModel>>($"/api/category/{_categoryId}/runs?limit=1&status=any&offset=1", new());
             returned5.Data.Single().Should().BeEquivalentTo(RunViewModel.MapFrom(runs[2]));
             returned5.Total.Should().Be(3);
         }

--- a/LeaderboardBackend/Controllers/CategoriesController.cs
+++ b/LeaderboardBackend/Controllers/CategoriesController.cs
@@ -61,10 +61,10 @@ public class CategoriesController(ICategoryService categoryService) : ApiControl
     public async Task<ActionResult<ListView<CategoryViewModel>>> GetCategoriesForLeaderboard(
         [FromRoute] long id,
         [FromQuery] Page page,
-        [FromQuery, SwaggerParameter(Description = "Whether to include deleted Categories. Defaults to `false`.")] bool includeDeleted = false
+        [FromQuery] StatusFilter status = StatusFilter.Published
     )
     {
-        GetCategoriesForLeaderboardResult r = await categoryService.GetCategoriesForLeaderboard(id, includeDeleted, page);
+        GetCategoriesForLeaderboardResult r = await categoryService.GetCategoriesForLeaderboard(id, status, page);
 
         return r.Match<ActionResult<ListView<CategoryViewModel>>>(
             categories => Ok(new ListView<CategoryViewModel>

--- a/LeaderboardBackend/Controllers/LeaderboardsController.cs
+++ b/LeaderboardBackend/Controllers/LeaderboardsController.cs
@@ -56,9 +56,9 @@ public class LeaderboardsController(
     [SwaggerOperation("Gets all leaderboards.", OperationId = "listLeaderboards")]
     [SwaggerResponse(200)]
     [SwaggerResponse(422, Type = typeof(ValidationProblemDetails))]
-    public async Task<ActionResult<ListView<LeaderboardViewModel>>> GetLeaderboards([FromQuery] Page page, [FromQuery] bool includeDeleted = false)
+    public async Task<ActionResult<ListView<LeaderboardViewModel>>> GetLeaderboards([FromQuery] Page page, [FromQuery] StatusFilter status = StatusFilter.Published)
     {
-        ListResult<Leaderboard> result = await leaderboardService.ListLeaderboards(includeDeleted, page);
+        ListResult<Leaderboard> result = await leaderboardService.ListLeaderboards(status, page);
         return Ok(new ListView<LeaderboardViewModel>()
         {
             Data = result.Items.Select(LeaderboardViewModel.MapFrom).ToList(),

--- a/LeaderboardBackend/Controllers/RunsController.cs
+++ b/LeaderboardBackend/Controllers/RunsController.cs
@@ -115,10 +115,10 @@ public class RunsController(
     public async Task<ActionResult<ListView<RunViewModel>>> GetRunsForCategory(
         [FromRoute] long id,
         [FromQuery] Page page,
-        [FromQuery, SwaggerParameter(Required = false, Description = "Whether to include deleted runs. Defaults false.")] bool includeDeleted = false
+        [FromQuery] StatusFilter status = StatusFilter.Published
     )
     {
-        GetRunsForCategoryResult result = await runService.GetRunsForCategory(id, page, includeDeleted);
+        GetRunsForCategoryResult result = await runService.GetRunsForCategory(id, status, page);
 
         return result.Match<ActionResult>(
             runs => Ok(new ListView<RunViewModel>()

--- a/LeaderboardBackend/LeaderboardBackend.csproj
+++ b/LeaderboardBackend/LeaderboardBackend.csproj
@@ -49,9 +49,9 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.SourceGenerator" Version="3.0.271" />
     <PackageReference Include="ReHackt.Extensions.Options.Validation" Version="8.0.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="8.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LeaderboardBackend/Models/Entities/Category.cs
+++ b/LeaderboardBackend/Models/Entities/Category.cs
@@ -15,7 +15,7 @@ public enum SortDirection
 /// <summary>
 ///     Represents a `Category` tied to a `Leaderboard`.
 /// </summary>
-public class Category : IHasUpdateTimestamp
+public class Category : IHasUpdateTimestamp, IHasDeletionTimestamp
 {
     /// <summary>
     ///     The unique identifier of the `Category`.<br/>

--- a/LeaderboardBackend/Models/Entities/IHasDeletionTimestamp.cs
+++ b/LeaderboardBackend/Models/Entities/IHasDeletionTimestamp.cs
@@ -5,11 +5,9 @@ namespace LeaderboardBackend.Models.Entities;
 public interface IHasDeletionTimestamp : IHasCreationTimestamp
 {
     Instant? DeletedAt { get; set; }
-
-    public Status Status => DeletedAt == null ? Status.Published : Status.Deleted;
 }
 
 public static class HasDeletionTimestamp
 {
-    public static Status Status(this IHasDeletionTimestamp entity) => entity.Status;
+    public static Status Status(this IHasDeletionTimestamp entity) => entity.DeletedAt is null ? Models.Status.Published : Models.Status.Deleted;
 }

--- a/LeaderboardBackend/Models/Entities/IHasDeletionTimestamp.cs
+++ b/LeaderboardBackend/Models/Entities/IHasDeletionTimestamp.cs
@@ -1,0 +1,15 @@
+using NodaTime;
+
+namespace LeaderboardBackend.Models.Entities;
+
+public interface IHasDeletionTimestamp : IHasCreationTimestamp
+{
+    Instant? DeletedAt { get; set; }
+
+    public Status Status => DeletedAt == null ? Status.Published : Status.Deleted;
+}
+
+public static class HasDeletionTimestamp
+{
+    public static Status Status(this IHasDeletionTimestamp entity) => entity.Status;
+}

--- a/LeaderboardBackend/Models/Entities/Leaderboard.cs
+++ b/LeaderboardBackend/Models/Entities/Leaderboard.cs
@@ -9,7 +9,7 @@ namespace LeaderboardBackend.Models.Entities;
 /// <summary>
 ///     Represents a collection of `Category` entities.
 /// </summary>
-public class Leaderboard : IHasUpdateTimestamp
+public class Leaderboard : IHasUpdateTimestamp, IHasDeletionTimestamp
 {
     /// <summary>
     ///     The unique identifier of the `Leaderboard`.<br/>

--- a/LeaderboardBackend/Models/Entities/Run.cs
+++ b/LeaderboardBackend/Models/Entities/Run.cs
@@ -8,7 +8,7 @@ namespace LeaderboardBackend.Models.Entities;
 /// <summary>
 ///     Represents an entry on a `Category`.
 /// </summary>
-public class Run : IHasUpdateTimestamp
+public class Run : IHasUpdateTimestamp, IHasDeletionTimestamp
 {
     /// <summary>
     ///     The unique identifier of the `Run`.<br/>

--- a/LeaderboardBackend/Models/Requests/StatusFilter.cs
+++ b/LeaderboardBackend/Models/Requests/StatusFilter.cs
@@ -22,5 +22,5 @@ public static class StatusFilterMethods
         };
 
     public static IEnumerable<T> FilterByStatus<T>(this IEnumerable<T> enumerable, StatusFilter statusFilter) where T : IHasDeletionTimestamp
-        => enumerable.Where(ent => statusFilter == StatusFilter.Any || ((int)statusFilter) == (int)ent.Status);
+        => enumerable.Where(ent => statusFilter == StatusFilter.Any || ((int)statusFilter) == (int)ent.Status());
 }

--- a/LeaderboardBackend/Models/Requests/StatusFilter.cs
+++ b/LeaderboardBackend/Models/Requests/StatusFilter.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel;
+using LeaderboardBackend.Models.Entities;
+
+namespace LeaderboardBackend.Models.Requests;
+
+public enum StatusFilter
+{
+    Published,
+    Deleted,
+    Any
+}
+
+public static class StatusFilterMethods
+{
+    public static IQueryable<T> FilterByStatus<T>(this IQueryable<T> queryable, StatusFilter statusFilter) where T : IHasDeletionTimestamp
+        => statusFilter switch
+        {
+            StatusFilter.Any => queryable,
+            StatusFilter.Published => queryable.Where(ent => ent.DeletedAt == null),
+            StatusFilter.Deleted => queryable.Where(ent => ent.DeletedAt != null),
+            _ => throw new InvalidEnumArgumentException(nameof(statusFilter), (int)statusFilter, typeof(StatusFilter))
+        };
+
+    public static IEnumerable<T> FilterByStatus<T>(this IEnumerable<T> enumerable, StatusFilter statusFilter) where T : IHasDeletionTimestamp
+        => enumerable.Where(ent => statusFilter == StatusFilter.Any || ((int)statusFilter) == (int)ent.Status);
+}

--- a/LeaderboardBackend/Models/Status.cs
+++ b/LeaderboardBackend/Models/Status.cs
@@ -1,0 +1,7 @@
+namespace LeaderboardBackend.Models;
+
+public enum Status
+{
+    Published,
+    Deleted
+}

--- a/LeaderboardBackend/Models/ViewModels/CategoryViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/CategoryViewModel.cs
@@ -49,6 +49,8 @@ public record CategoryViewModel
     /// <inheritdoc cref="Category.DeletedAt" />
     public required Instant? DeletedAt { get; set; }
 
+    public required Status Status { get; set; }
+
     public static CategoryViewModel MapFrom(Category category) => new()
     {
         Id = category.Id,
@@ -60,6 +62,7 @@ public record CategoryViewModel
         LeaderboardId = category.LeaderboardId,
         CreatedAt = category.CreatedAt,
         UpdatedAt = category.UpdatedAt,
-        DeletedAt = category.DeletedAt
+        DeletedAt = category.DeletedAt,
+        Status = category.Status()
     };
 }

--- a/LeaderboardBackend/Models/ViewModels/LeaderboardViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/LeaderboardViewModel.cs
@@ -48,6 +48,8 @@ public record LeaderboardViewModel
     /// </summary>
     public required Instant? DeletedAt { get; set; }
 
+    public required Status Status { get; set; }
+
     public static LeaderboardViewModel MapFrom(Leaderboard leaderboard) => new()
     {
         Id = leaderboard.Id,
@@ -57,5 +59,6 @@ public record LeaderboardViewModel
         CreatedAt = leaderboard.CreatedAt,
         UpdatedAt = leaderboard.UpdatedAt,
         DeletedAt = leaderboard.DeletedAt,
+        Status = leaderboard.Status()
     };
 }

--- a/LeaderboardBackend/Models/ViewModels/RunViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/RunViewModel.cs
@@ -52,6 +52,8 @@ public abstract record RunViewModel
     /// </summary>
     public required Guid UserId { get; set; }
 
+    public required Status Status { get; set; }
+
     public static RunViewModel MapFrom(Run run) => run.Type switch
     {
         RunType.Time => new TimedRunViewModel
@@ -65,7 +67,8 @@ public abstract record RunViewModel
             DeletedAt = run.DeletedAt,
             Info = run.Info,
             Time = run.Time,
-            RunType = run.Type
+            RunType = run.Type,
+            Status = run.Status()
         },
         RunType.Score => new ScoredRunViewModel
         {
@@ -78,7 +81,8 @@ public abstract record RunViewModel
             DeletedAt = run.DeletedAt,
             Info = run.Info,
             Score = run.TimeOrScore,
-            RunType = run.Type
+            RunType = run.Type,
+            Status = run.Status()
         },
         _ => throw new NotImplementedException(),
     };

--- a/LeaderboardBackend/Program.cs
+++ b/LeaderboardBackend/Program.cs
@@ -160,6 +160,7 @@ builder.Services.AddSwaggerGen(c =>
     string xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
     c.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));
     c.EnableAnnotations(true, true);
+    c.UseAllOfToExtendReferenceSchemas();
 
     c.AddSecurityDefinition(
         "Bearer",

--- a/LeaderboardBackend/Services/ICategoryService.cs
+++ b/LeaderboardBackend/Services/ICategoryService.cs
@@ -10,7 +10,7 @@ public interface ICategoryService
 {
     Task<Category?> GetCategory(long id);
     Task<Category?> GetCategoryBySlug(long leaderboardId, string slug);
-    Task<GetCategoriesForLeaderboardResult> GetCategoriesForLeaderboard(long leaderboardId, bool includeDeleted, Page page);
+    Task<GetCategoriesForLeaderboardResult> GetCategoriesForLeaderboard(long leaderboardId, StatusFilter statusFilter, Page page);
     Task<CreateCategoryResult> CreateCategory(long leaderboardId, CreateCategoryRequest request);
     Task<Category?> GetCategoryForRun(Run run);
     Task<UpdateResult<Category>> UpdateCategory(long id, UpdateCategoryRequest request);

--- a/LeaderboardBackend/Services/ILeaderboardService.cs
+++ b/LeaderboardBackend/Services/ILeaderboardService.cs
@@ -9,7 +9,7 @@ public interface ILeaderboardService
 {
     Task<Leaderboard?> GetLeaderboard(long id);
     Task<Leaderboard?> GetLeaderboardBySlug(string slug);
-    Task<ListResult<Leaderboard>> ListLeaderboards(bool includeDeleted, Page page);
+    Task<ListResult<Leaderboard>> ListLeaderboards(StatusFilter statusFilter, Page page);
     Task<CreateLeaderboardResult> CreateLeaderboard(CreateLeaderboardRequest request);
     Task<RestoreResult<Leaderboard>> RestoreLeaderboard(long id);
     Task<DeleteResult> DeleteLeaderboard(long id);

--- a/LeaderboardBackend/Services/IRunService.cs
+++ b/LeaderboardBackend/Services/IRunService.cs
@@ -9,7 +9,7 @@ namespace LeaderboardBackend.Services;
 public interface IRunService
 {
     Task<Run?> GetRun(Guid id);
-    Task<GetRunsForCategoryResult> GetRunsForCategory(long id, Page page, bool includeDeleted = false);
+    Task<GetRunsForCategoryResult> GetRunsForCategory(long id, StatusFilter statusFilter, Page page);
     Task<CreateRunResult> CreateRun(User user, Category category, CreateRunRequest request);
     /// <returns>
     ///     One of four cases (none of which return any inner data):

--- a/LeaderboardBackend/Services/Impl/LeaderboardService.cs
+++ b/LeaderboardBackend/Services/Impl/LeaderboardService.cs
@@ -17,10 +17,9 @@ public class LeaderboardService(ApplicationContext applicationContext, IClock cl
         await applicationContext.Leaderboards
             .FirstOrDefaultAsync(b => b.Slug == slug && b.DeletedAt == null);
 
-    public async Task<ListResult<Leaderboard>> ListLeaderboards(bool includeDeleted, Page page)
+    public async Task<ListResult<Leaderboard>> ListLeaderboards(StatusFilter statusFilter, Page page)
     {
-        IQueryable<Leaderboard> lbs = applicationContext.Leaderboards;
-        IQueryable<Leaderboard> query = includeDeleted ? lbs : lbs.Where(lb => lb.DeletedAt == null);
+        IQueryable<Leaderboard> query = applicationContext.Leaderboards.FilterByStatus(statusFilter);
         long count = await query.LongCountAsync();
 
         // Ordering by ID is necessary, otherwise pagination breaks completely because the records won't

--- a/LeaderboardBackend/Services/Impl/RunService.cs
+++ b/LeaderboardBackend/Services/Impl/RunService.cs
@@ -15,8 +15,8 @@ public class RunService(ApplicationContext applicationContext, IClock clock) : I
 
     public async Task<GetRunsForCategoryResult> GetRunsForCategory(
         long id,
-        Page page,
-        bool includeDeleted = false
+        StatusFilter statusFilter,
+        Page page
     )
     {
         Category? cat = await applicationContext.FindAsync<Category>(id);
@@ -27,9 +27,7 @@ public class RunService(ApplicationContext applicationContext, IClock clock) : I
 
         IQueryable<Run> query = applicationContext.Runs
             .Include(run => run.Category)
-            .Where(run =>
-                run.CategoryId == id && (includeDeleted || run.DeletedAt == null)
-            );
+            .FilterByStatus(statusFilter);
 
         long count = await query.LongCountAsync();
 

--- a/LeaderboardBackend/openapi.json
+++ b/LeaderboardBackend/openapi.json
@@ -2142,7 +2142,11 @@
         "type": "object",
         "properties": {
           "runType": {
-            "$ref": "#/components/schemas/RunType"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RunType"
+              }
+            ]
           },
           "info": {
             "type": "string"
@@ -2700,7 +2704,11 @@
         "type": "object",
         "properties": {
           "runType": {
-            "$ref": "#/components/schemas/RunType"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RunType"
+              }
+            ]
           },
           "info": {
             "type": "string"

--- a/LeaderboardBackend/openapi.json
+++ b/LeaderboardBackend/openapi.json
@@ -17,7 +17,12 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/RegisterRequest"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/RegisterRequest"
+                  }
+                ],
+                "description": "This request object is sent when a `User` is attempting to register."
               }
             }
           },
@@ -82,7 +87,12 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/LoginRequest"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LoginRequest"
+                  }
+                ],
+                "description": "This request object is sent when a `User` is attempting to log in."
               }
             }
           },
@@ -179,7 +189,11 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/RecoverAccountRequest"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/RecoverAccountRequest"
+                  }
+                ]
               }
             }
           }
@@ -313,7 +327,11 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ChangePasswordRequest"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ChangePasswordRequest"
+                  }
+                ]
               }
             }
           },
@@ -506,12 +524,15 @@
             }
           },
           {
-            "name": "includeDeleted",
+            "name": "status",
             "in": "query",
-            "description": "Whether to include deleted Categories. Defaults to `false`.",
             "schema": {
-              "type": "boolean",
-              "default": false
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/StatusFilter"
+                }
+              ],
+              "default": "Published"
             }
           }
         ],
@@ -584,7 +605,12 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateCategoryRequest"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateCategoryRequest"
+                  }
+                ],
+                "description": "This request object is sent when creating a `Category`."
               }
             }
           },
@@ -675,7 +701,11 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateCategoryRequest"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateCategoryRequest"
+                  }
+                ]
               }
             }
           },
@@ -983,11 +1013,15 @@
             }
           },
           {
-            "name": "includeDeleted",
+            "name": "status",
             "in": "query",
             "schema": {
-              "type": "boolean",
-              "default": false
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/StatusFilter"
+                }
+              ],
+              "default": "Published"
             }
           }
         ],
@@ -1039,7 +1073,12 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateLeaderboardRequest"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateLeaderboardRequest"
+                  }
+                ],
+                "description": "This request object is sent when creating a `Leaderboard`."
               }
             }
           },
@@ -1243,7 +1282,11 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateLeaderboardRequest"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/UpdateLeaderboardRequest"
+                  }
+                ]
               }
             }
           },
@@ -1514,12 +1557,15 @@
             }
           },
           {
-            "name": "includeDeleted",
+            "name": "status",
             "in": "query",
-            "description": "Whether to include deleted runs. Defaults false.",
             "schema": {
-              "type": "boolean",
-              "default": false
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/StatusFilter"
+                }
+              ],
+              "default": "Published"
             }
           }
         ],
@@ -1862,6 +1908,7 @@
           "name",
           "slug",
           "sortDirection",
+          "status",
           "type",
           "updatedAt"
         ],
@@ -1889,10 +1936,18 @@
             "example": "Video proof is required."
           },
           "type": {
-            "$ref": "#/components/schemas/RunType"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RunType"
+              }
+            ]
           },
           "sortDirection": {
-            "$ref": "#/components/schemas/SortDirection"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SortDirection"
+              }
+            ]
           },
           "leaderboardId": {
             "type": "integer",
@@ -1914,6 +1969,13 @@
             "format": "date-time",
             "nullable": true,
             "example": "1984-01-01T00:00:00Z"
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Status"
+              }
+            ]
           }
         },
         "additionalProperties": false,
@@ -1944,7 +2006,13 @@
             "nullable": true
           },
           "conflicting": {
-            "$ref": "#/components/schemas/CategoryViewModel"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CategoryViewModel"
+              }
+            ],
+            "description": "Represents a `Category` tied to a `Leaderboard`.",
+            "nullable": true
           }
         },
         "additionalProperties": { },
@@ -2023,10 +2091,18 @@
             "example": "Video proof is required."
           },
           "sortDirection": {
-            "$ref": "#/components/schemas/SortDirection"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SortDirection"
+              }
+            ]
           },
           "type": {
-            "$ref": "#/components/schemas/RunType"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RunType"
+              }
+            ]
           }
         },
         "additionalProperties": false,
@@ -2140,6 +2216,7 @@
           "info",
           "name",
           "slug",
+          "status",
           "updatedAt"
         ],
         "type": "object",
@@ -2183,6 +2260,13 @@
             "format": "date-time",
             "nullable": true,
             "example": "1984-01-01T00:00:00Z"
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Status"
+              }
+            ]
           }
         },
         "additionalProperties": false,
@@ -2213,7 +2297,13 @@
             "nullable": true
           },
           "conflicting": {
-            "$ref": "#/components/schemas/LeaderboardViewModel"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LeaderboardViewModel"
+              }
+            ],
+            "description": "Represents a collection of `Leaderboard` entities.",
+            "nullable": true
           }
         },
         "additionalProperties": { },
@@ -2385,13 +2475,18 @@
           "info",
           "playedOn",
           "runType",
+          "status",
           "updatedAt",
           "userId"
         ],
         "type": "object",
         "properties": {
           "runType": {
-            "$ref": "#/components/schemas/RunType"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RunType"
+              }
+            ]
           },
           "id": {
             "pattern": "^[a-zA-Z0-9-_]{22}$",
@@ -2438,6 +2533,13 @@
             "pattern": "^[a-zA-Z0-9-_]{22}$",
             "type": "string",
             "description": "The ID of the LeaderboardBackend.Models.Entities.User who submitted this run."
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Status"
+              }
+            ]
           }
         },
         "additionalProperties": false,
@@ -2517,6 +2619,21 @@
         ],
         "type": "string"
       },
+      "Status": {
+        "enum": [
+          "Published",
+          "Deleted"
+        ],
+        "type": "string"
+      },
+      "StatusFilter": {
+        "enum": [
+          "Published",
+          "Deleted",
+          "Any"
+        ],
+        "type": "string"
+      },
       "TimedRunViewModel": {
         "allOf": [
           {
@@ -2551,7 +2668,12 @@
             "type": "string"
           },
           "sortDirection": {
-            "$ref": "#/components/schemas/SortDirection"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SortDirection"
+              }
+            ],
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -2665,7 +2787,11 @@
             "example": "J'on-Doe"
           },
           "role": {
-            "$ref": "#/components/schemas/UserRole"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UserRole"
+              }
+            ]
           },
           "createdAt": {
             "type": "string",


### PR DESCRIPTION
This PR adds a new Status field to all resources that can be deleted and changes any endpoints that return a list of these resources to take a status filter param instead of `includeDeleted`. Swagger settings are also updated so that enum values will have their defaults recorded in the spec if present. Closes #309.