### PR TITLE
Call Update() to Update User Roles in Category Tests

### DIFF
--- a/LeaderboardBackend.Test/Categories.cs
+++ b/LeaderboardBackend.Test/Categories.cs
@@ -297,11 +297,15 @@ internal class Categories
 
     [TestCase(-1, 0)]
     [TestCase(1024, -1)]
-    public async Task GetCategoriesForLeaderboard_BadPageData(int limit, int offset)
-    {
-        await FluentActions.Awaiting(() => _apiClient.Get<ListView<CategoryViewModel>>($"/api/leaderboard/54/categories?limit={limit}&offset={offset}", new()))
-            .Should().ThrowAsync<RequestFailureException>().Where(ex => ex.Response.StatusCode == HttpStatusCode.UnprocessableContent);
-    }
+    public async Task GetCategoriesForLeaderboard_BadPageData(int limit, int offset) =>
+        await _apiClient.Awaiting(
+            a => a.Get<ListView<CategoryViewModel>>(
+                $"/api/leaderboard/54/categories?limit={limit}&offset={offset}",
+                new()
+            )
+        ).Should()
+        .ThrowAsync<RequestFailureException>()
+        .Where(ex => ex.Response.StatusCode == HttpStatusCode.UnprocessableContent);
 
     [Test]
     public async Task GetCategoriesForLeaderboard_NotFound() =>

--- a/LeaderboardBackend.Test/Categories.cs
+++ b/LeaderboardBackend.Test/Categories.cs
@@ -371,9 +371,10 @@ internal class Categories
     public async Task CreateCategory_BadRole(UserRole role)
     {
         IServiceScope scope = _factory.Services.CreateScope();
+        ApplicationContext context = scope.ServiceProvider.GetRequiredService<ApplicationContext>();
         IUserService userService = scope.ServiceProvider.GetRequiredService<IUserService>();
 
-        string email = $"testuser.updatecat.{role}@example.com";
+        string email = $"testuser.createcat.{role}@example.com";
 
         RegisterRequest registerRequest = new()
         {
@@ -382,8 +383,14 @@ internal class Categories
             Username = $"CreateCatTest{role}"
         };
 
-        await userService.CreateUser(registerRequest);
+        CreateUserResult createUserResult = await userService.CreateUser(registerRequest);
         LoginResponse res = await _apiClient.LoginUser(registerRequest.Email, registerRequest.Password);
+
+        createUserResult.IsT0.Should().BeTrue();
+        User user = createUserResult.AsT0;
+        context.Update(user);
+        user.Role = role;
+        await context.SaveChangesAsync();
 
         CreateCategoryRequest request = new()
         {
@@ -642,8 +649,14 @@ internal class Categories
             Username = $"UpdateCatTest{role}"
         };
 
-        await userService.CreateUser(registerRequest);
+        CreateUserResult createUserResult = await userService.CreateUser(registerRequest);
         LoginResponse res = await _apiClient.LoginUser(registerRequest.Email, registerRequest.Password);
+
+        createUserResult.IsT0.Should().BeTrue();
+        User user = createUserResult.AsT0;
+        context.Update(user);
+        user.Role = role;
+        await context.SaveChangesAsync();
 
         await FluentActions.Awaiting(() => _apiClient.Patch(
             $"category/{cat.Id}",
@@ -997,8 +1010,13 @@ internal class Categories
             Username = $"DeleteCatTest{role}"
         };
 
-        await userService.CreateUser(registerRequest);
+        CreateUserResult createUserResult = await userService.CreateUser(registerRequest);
         LoginResponse res = await _apiClient.LoginUser(registerRequest.Email, registerRequest.Password);
+
+        createUserResult.IsT0.Should().BeTrue();
+        User user = createUserResult.AsT0;
+        context.Update(user);
+        user.Role = role;
 
         Category cat = new()
         {
@@ -1174,8 +1192,14 @@ internal class Categories
             Username = $"RestoreCatTest{role}"
         };
 
-        await userService.CreateUser(registerRequest);
+        CreateUserResult createUserResult = await userService.CreateUser(registerRequest);
         LoginResponse res = await _apiClient.LoginUser(registerRequest.Email, registerRequest.Password);
+
+        createUserResult.IsT0.Should().BeTrue();
+        User user = createUserResult.AsT0;
+        context.Update(user);
+        user.Role = role;
+        await context.SaveChangesAsync();
 
         await FluentActions.Awaiting(() => _apiClient.Put<CategoryViewModel>(
             $"category/{cat.Id}/restore",


### PR DESCRIPTION
In tests that set the user role, this PR saves a transaction call by replacing `FindAsync` calls with `Update` calls. This PR also fills in tests that don't actually update the user role when they're supposed to.