### PR TITLE
Reduce Login Error Specificity

### DIFF
--- a/LeaderboardBackend.Test/Features/Users/LoginTests.cs
+++ b/LeaderboardBackend.Test/Features/Users/LoginTests.cs
@@ -2,7 +2,6 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using System.Security.Claims;
 using System.Threading.Tasks;
 using LeaderboardBackend.Authorization;
 using LeaderboardBackend.Models.Entities;
@@ -113,6 +112,7 @@ public class LoginTests : IntegrationTestsBase
 
     [TestCase("valid@user.com", "Inc0rrectPassword", HttpStatusCode.Unauthorized, Description = "Wrong password")]
     [TestCase("banned@user.com", "P4ssword", HttpStatusCode.Forbidden, Description = "Banned user")]
+    [TestCase("banned@user.com", "Inc0rrectPassword", HttpStatusCode.Unauthorized, Description = "Wrong email")]
     [TestCase("unknown@user.com", "Inc0rrectPassword", HttpStatusCode.Unauthorized, Description = "Wrong email")]
     public async Task Login_InvalidRequest_OtherErrors(string email, string password, HttpStatusCode statusCode)
     {

--- a/LeaderboardBackend.Test/Features/Users/LoginTests.cs
+++ b/LeaderboardBackend.Test/Features/Users/LoginTests.cs
@@ -112,8 +112,8 @@ public class LoginTests : IntegrationTestsBase
     }
 
     [TestCase("valid@user.com", "Inc0rrectPassword", HttpStatusCode.Unauthorized, Description = "Wrong password")]
-    [TestCase("banned@user.com", "Inc0rrectPassword", HttpStatusCode.Forbidden, Description = "Banned user")]
-    [TestCase("unknown@user.com", "Inc0rrectPassword", HttpStatusCode.NotFound, Description = "Wrong email")]
+    [TestCase("banned@user.com", "P4ssword", HttpStatusCode.Forbidden, Description = "Banned user")]
+    [TestCase("unknown@user.com", "Inc0rrectPassword", HttpStatusCode.Unauthorized, Description = "Wrong email")]
     public async Task Login_InvalidRequest_OtherErrors(string email, string password, HttpStatusCode statusCode)
     {
         LoginRequest request = new()

--- a/LeaderboardBackend.Test/Features/Users/LoginTests.cs
+++ b/LeaderboardBackend.Test/Features/Users/LoginTests.cs
@@ -112,7 +112,7 @@ public class LoginTests : IntegrationTestsBase
 
     [TestCase("valid@user.com", "Inc0rrectPassword", HttpStatusCode.Unauthorized, Description = "Wrong password")]
     [TestCase("banned@user.com", "P4ssword", HttpStatusCode.Forbidden, Description = "Banned user")]
-    [TestCase("banned@user.com", "Inc0rrectPassword", HttpStatusCode.Unauthorized, Description = "Wrong email")]
+    [TestCase("banned@user.com", "Inc0rrectPassword", HttpStatusCode.Unauthorized, Description = "Banned user; wrong password")]
     [TestCase("unknown@user.com", "Inc0rrectPassword", HttpStatusCode.Unauthorized, Description = "Wrong email")]
     public async Task Login_InvalidRequest_OtherErrors(string email, string password, HttpStatusCode statusCode)
     {

--- a/LeaderboardBackend/Controllers/AccountController.cs
+++ b/LeaderboardBackend/Controllers/AccountController.cs
@@ -95,9 +95,8 @@ public class AccountController(IUserService userService) : ApiController
         "The `User` was logged in successfully. A `LoginResponse` is returned, containing a token.",
         typeof(LoginResponse)
     )]
-    [SwaggerResponse(401, "The password given was incorrect.")]
+    [SwaggerResponse(401, "The password given was incorrect, or no `User` could be found.")]
     [SwaggerResponse(403, "The associated `User` is banned.")]
-    [SwaggerResponse(404, "No `User` with the requested details could be found.")]
     [SwaggerResponse(
         422,
         """
@@ -123,7 +122,6 @@ public class AccountController(IUserService userService) : ApiController
 
         return result.Match<ActionResult<LoginResponse>>(
             loginToken => Ok(new LoginResponse { Token = loginToken }),
-            notFound => NotFound(),
             banned => Forbid(),
             badCredentials => Unauthorized()
         );

--- a/LeaderboardBackend/Controllers/AccountController.cs
+++ b/LeaderboardBackend/Controllers/AccountController.cs
@@ -122,6 +122,7 @@ public class AccountController(IUserService userService) : ApiController
 
         return result.Match<ActionResult<LoginResponse>>(
             loginToken => Ok(new LoginResponse { Token = loginToken }),
+            notFound => Unauthorized(),
             banned => Forbid(),
             badCredentials => Unauthorized()
         );

--- a/LeaderboardBackend/Services/IUserService.cs
+++ b/LeaderboardBackend/Services/IUserService.cs
@@ -27,7 +27,7 @@ public partial class CreateUserResult : OneOfBase<User, CreateUserConflicts> { }
 public readonly record struct CreateUserConflicts(bool Username = false, bool Email = false);
 
 [GenerateOneOf]
-public partial class LoginResult : OneOfBase<string, UserBanned, BadCredentials> { }
+public partial class LoginResult : OneOfBase<string, UserNotFound, UserBanned, BadCredentials> { }
 
 [GenerateOneOf]
 public partial class GetUserResult : OneOfBase<User, BadCredentials, UserNotFound> { }

--- a/LeaderboardBackend/Services/IUserService.cs
+++ b/LeaderboardBackend/Services/IUserService.cs
@@ -27,7 +27,7 @@ public partial class CreateUserResult : OneOfBase<User, CreateUserConflicts> { }
 public readonly record struct CreateUserConflicts(bool Username = false, bool Email = false);
 
 [GenerateOneOf]
-public partial class LoginResult : OneOfBase<string, UserNotFound, UserBanned, BadCredentials> { }
+public partial class LoginResult : OneOfBase<string, UserBanned, BadCredentials> { }
 
 [GenerateOneOf]
 public partial class GetUserResult : OneOfBase<User, BadCredentials, UserNotFound> { }

--- a/LeaderboardBackend/Services/Impl/UserService.cs
+++ b/LeaderboardBackend/Services/Impl/UserService.cs
@@ -46,11 +46,12 @@ public class UserService(ApplicationContext applicationContext, IAuthService aut
     {
         User? user = await applicationContext.Users.SingleOrDefaultAsync(user => user.Email == email);
 
-        // Previously, we return a 404 if no user exists in the DB, and a 401
-        // if one does, but with bad credentials. This separation however can
-        // be used to guess user's emails. We're keeping these together to help
-        // prevent that. - zysim
-        if (user is null || !BCryptNet.EnhancedVerify(password, user.Password))
+        if (user is null)
+        {
+            return new UserNotFound();
+        }
+
+        if (!BCryptNet.EnhancedVerify(password, user.Password))
         {
             return new BadCredentials();
         }

--- a/LeaderboardBackend/Services/Impl/UserService.cs
+++ b/LeaderboardBackend/Services/Impl/UserService.cs
@@ -3,7 +3,6 @@ using LeaderboardBackend.Models.Entities;
 using LeaderboardBackend.Models.Requests;
 using LeaderboardBackend.Result;
 using Microsoft.EntityFrameworkCore;
-using NodaTime;
 using Npgsql;
 using BCryptNet = BCrypt.Net.BCrypt;
 
@@ -12,10 +11,8 @@ namespace LeaderboardBackend.Services;
 public class UserService(ApplicationContext applicationContext, IAuthService authService) : IUserService
 {
     // TODO: Convert return sig to Task<GetUserResult>
-    public async Task<User?> GetUserById(Guid id)
-    {
-        return await applicationContext.Users.FindAsync(id);
-    }
+    public async Task<User?> GetUserById(Guid id) =>
+        await applicationContext.Users.FindAsync(id);
 
     public async Task<GetUserResult> GetUserFromClaims(ClaimsPrincipal claims)
     {
@@ -38,9 +35,7 @@ public class UserService(ApplicationContext applicationContext, IAuthService aut
 
     // TODO: Convert return sig to Task<GetUserResult>
     public async Task<User?> GetUserByEmail(string email)
-    {
-        return await applicationContext.Users.SingleOrDefaultAsync(user => user.Email == email);
-    }
+        => await applicationContext.Users.SingleOrDefaultAsync(user => user.Email == email);
 
     public async Task<LoginResult> LoginByEmailAndPassword(string email, string password)
     {
@@ -65,17 +60,13 @@ public class UserService(ApplicationContext applicationContext, IAuthService aut
     }
 
     // TODO: Convert return sig to Task<GetUserResult>
-    public async Task<User?> GetUserByName(string name)
-    {
-        return await applicationContext.Users.SingleOrDefaultAsync(user => user.Username == name);
-    }
+    public async Task<User?> GetUserByName(string name) =>
+        await applicationContext.Users.SingleOrDefaultAsync(user => user.Username == name);
 
     public async Task<User?> GetUserByNameAndEmail(string name, string email)
-    {
-        return await applicationContext.Users.SingleOrDefaultAsync(
+        => await applicationContext.Users.SingleOrDefaultAsync(
             user => user.Username == name && user.Email == email
         );
-    }
 
     public async Task<CreateUserResult> CreateUser(RegisterRequest request)
     {

--- a/LeaderboardBackend/openapi.json
+++ b/LeaderboardBackend/openapi.json
@@ -123,13 +123,10 @@
             }
           },
           "401": {
-            "description": "The password given was incorrect."
+            "description": "The password given was incorrect, or no `User` could be found."
           },
           "403": {
             "description": "The associated `User` is banned."
-          },
-          "404": {
-            "description": "No `User` with the requested details could be found."
           },
           "422": {
             "description": "The request contains errors.\nValidation error codes by property:\n- **Password**:\n  - **NotEmptyValidator**: No password was passed\n  - **PasswordFormat**: Invalid password format\n- **Email**:\n  - **NotEmptyValidator**: No email was passed\n  - **EmailValidator**: Invalid email format",


### PR DESCRIPTION
Closes: #176 

* 404 error becomes 401 (if a user isn't found in the DB, it 401s, same as bad credentials)
* 403 error check only triggers after checking password is correct, when it triggered before

Todos:
- [ ] Notify FE when this is approved