### PR TITLE
Pluralize Routes

### DIFF
--- a/LeaderboardBackend.Test/Categories.cs
+++ b/LeaderboardBackend.Test/Categories.cs
@@ -47,7 +47,7 @@ internal class Categories
         _jwt = (await _apiClient.LoginAdminUser()).Token;
 
         _createdLeaderboard = await _apiClient.Post<LeaderboardViewModel>(
-            "/leaderboards/create",
+            "/leaderboards",
             new()
             {
                 Body = new CreateLeaderboardRequest()
@@ -84,7 +84,7 @@ internal class Categories
 
         await _apiClient.Awaiting(
             a => a.Get<CategoryViewModel>(
-                $"api/category/{created.Id}",
+                $"api/categories/{created.Id}",
                 new() { }
             )
         ).Should()
@@ -110,7 +110,7 @@ internal class Categories
     public async Task GetCategoryByID_NotFound(object id) =>
         await _apiClient.Awaiting(
             a => a.Get<CategoryViewModel>(
-                $"/api/category/{id}",
+                $"/api/categories/{id}",
                 new() { Jwt = _jwt }
             )
         ).Should()
@@ -138,7 +138,7 @@ internal class Categories
 
         await _apiClient.Awaiting(
             a => a.Get<CategoryViewModel>(
-                $"api/leaderboard/{_createdLeaderboard.Id}/category?slug=getcategory-slug-ok",
+                $"api/leaderboards/{_createdLeaderboard.Id}/categories/getcategory-slug-ok",
                 new() { }
             )
         ).Should()
@@ -163,7 +163,7 @@ internal class Categories
     public async Task GetCategoryBySlug_NotFound_WrongSlug() =>
         await _apiClient.Awaiting(
             a => a.Get<CategoryViewModel>(
-                $"api/leaderboard/{_createdLeaderboard.Id}/category?slug=wrong-slug",
+                $"api/leaderboards/{_createdLeaderboard.Id}/categories/wrong-slug",
                 new() { }
             )
         ).Should()
@@ -192,7 +192,7 @@ internal class Categories
 
         await _apiClient.Awaiting(
             a => a.Get<CategoryViewModel>(
-                $"api/leaderboard/{short.MaxValue}/category?slug={created.Slug}",
+                $"api/leaderboards/{short.MaxValue}/categories/{created.Slug}",
                 new() { }
             )
         ).Should()
@@ -222,7 +222,7 @@ internal class Categories
 
         await _apiClient.Awaiting(
             a => a.Get<CategoryViewModel>(
-                $"api/leaderboard/{_createdLeaderboard.Id}/category?slug={created.Slug}",
+                $"api/leaderboards/{_createdLeaderboard.Id}/categories/{created.Slug}",
                 new() { }
             )
         ).Should()
@@ -271,7 +271,7 @@ internal class Categories
         board.Id.Should().NotBe(default);
 
         ListView<CategoryViewModel> resultSansDeleted = await _apiClient.Get<ListView<CategoryViewModel>>(
-            $"api/leaderboard/{board.Id}/categories?limit=99999999",
+            $"api/leaderboards/{board.Id}/categories?limit=99999999",
             new() { }
         );
         resultSansDeleted.Data.Should().BeEquivalentTo(board.Categories.Take(2), opts => opts.ExcludingMissingMembers());
@@ -279,7 +279,7 @@ internal class Categories
         resultSansDeleted.LimitDefault.Should().Be(64);
 
         ListView<CategoryViewModel> resultWithDeleted = await _apiClient.Get<ListView<CategoryViewModel>>(
-            $"api/leaderboard/{board.Id}/categories?status=any",
+            $"api/leaderboards/{board.Id}/categories?status=any",
             new() { }
         );
 
@@ -290,7 +290,7 @@ internal class Categories
         await context.SaveChangesAsync();
 
         ListView<CategoryViewModel> resultEmpty = await _apiClient.Get<ListView<CategoryViewModel>>(
-            $"api/leaderboard/{board.Id}/categories",
+            $"api/leaderboards/{board.Id}/categories",
             new() { }
         );
 
@@ -302,7 +302,7 @@ internal class Categories
     public async Task GetCategoriesForLeaderboard_BadPageData(int limit, int offset) =>
         await _apiClient.Awaiting(
             a => a.Get<ListView<CategoryViewModel>>(
-                $"/api/leaderboard/54/categories?limit={limit}&offset={offset}",
+                $"/api/leaderboards/54/categories?limit={limit}&offset={offset}",
                 new()
             )
         ).Should()
@@ -313,7 +313,7 @@ internal class Categories
     public async Task GetCategoriesForLeaderboard_NotFound() =>
         await _apiClient.Awaiting(
             a => a.Get<CategoryViewModel>(
-                $"api/leaderboard/{short.MaxValue}/categories",
+                $"api/leaderboards/{short.MaxValue}/categories",
                 new() { }
             )
         ).Should()
@@ -333,7 +333,7 @@ internal class Categories
         };
 
         CategoryViewModel createdCategory = await _apiClient.Post<CategoryViewModel>(
-            $"/leaderboard/{_createdLeaderboard.Id}/categories/create",
+            $"/leaderboards/{_createdLeaderboard.Id}/categories",
             new()
             {
                 Body = request,
@@ -344,7 +344,7 @@ internal class Categories
         createdCategory.CreatedAt.Should().Be(_clock.GetCurrentInstant());
 
         CategoryViewModel retrievedCategory = await _apiClient.Get<CategoryViewModel>(
-            $"/api/category/{createdCategory?.Id}", new() { }
+            $"/api/categories/{createdCategory?.Id}", new() { }
         );
 
         retrievedCategory.Should().BeEquivalentTo(request);
@@ -363,7 +363,7 @@ internal class Categories
         };
 
         await FluentActions.Awaiting(() => _apiClient.Post<CategoryViewModel>(
-            $"/leaderboard/{_createdLeaderboard.Id}/categories/create",
+            $"/leaderboards/{_createdLeaderboard.Id}/categories",
             new()
             {
                 Body = request,
@@ -408,7 +408,7 @@ internal class Categories
         };
 
         await FluentActions.Awaiting(() => _apiClient.Post<CategoryViewModel>(
-            $"/leaderboard/{_createdLeaderboard.Id}/categories/create",
+            $"/leaderboards/{_createdLeaderboard.Id}/categories",
             new()
             {
                 Body = request,
@@ -430,7 +430,7 @@ internal class Categories
         };
 
         ExceptionAssertions<RequestFailureException> exAssert = await FluentActions.Awaiting(() => _apiClient.Post<CategoryViewModel>(
-            "/leaderboard/1000/categories/create",
+            "/leaderboards/1000/categories",
             new()
             {
                 Body = request,
@@ -472,7 +472,7 @@ internal class Categories
         };
 
         await FluentActions.Awaiting(() => _apiClient.Post<CategoryViewModel>(
-            $"/leaderboard/{_createdLeaderboard.Id}/categories/create",
+            $"/leaderboards/{_createdLeaderboard.Id}/categories",
             new()
             {
                 Body = request,
@@ -494,7 +494,7 @@ internal class Categories
         };
 
         CategoryViewModel created = await _apiClient.Post<CategoryViewModel>(
-            $"/leaderboard/{_createdLeaderboard.Id}/categories/create",
+            $"/leaderboards/{_createdLeaderboard.Id}/categories",
             new()
             {
                 Body = request,
@@ -503,7 +503,7 @@ internal class Categories
         );
 
         ExceptionAssertions<RequestFailureException> exAssert = await FluentActions.Awaiting(() => _apiClient.Post<CategoryViewModel>(
-            $"/leaderboard/{_createdLeaderboard.Id}/categories/create",
+            $"/leaderboards/{_createdLeaderboard.Id}/categories",
             new()
             {
                 Body = request,
@@ -531,7 +531,7 @@ internal class Categories
         };
 
         ExceptionAssertions<RequestFailureException> exAssert = await FluentActions.Awaiting(() => _apiClient.Post<CategoryViewModel>(
-            $"/leaderboard/{_createdLeaderboard.Id}/categories/create",
+            $"/leaderboards/{_createdLeaderboard.Id}/categories",
             new()
             {
                 Body = request,
@@ -565,7 +565,7 @@ internal class Categories
         context.ChangeTracker.Clear();
 
         HttpResponseMessage response = await _apiClient.Patch(
-            $"category/{created.Id}",
+            $"categories/{created.Id}",
             new()
             {
                 Body = new UpdateCategoryRequest()
@@ -609,7 +609,7 @@ internal class Categories
         context.ChangeTracker.Clear();
 
         await FluentActions.Awaiting(() => _apiClient.Patch(
-            $"category/{cat.Id}",
+            $"categories/{cat.Id}",
             new()
             {
                 Body = new UpdateCategoryRequest
@@ -665,7 +665,7 @@ internal class Categories
         await context.SaveChangesAsync();
 
         await FluentActions.Awaiting(() => _apiClient.Patch(
-            $"category/{cat.Id}",
+            $"categories/{cat.Id}",
             new()
             {
                 Body = new UpdateCategoryRequest
@@ -683,7 +683,7 @@ internal class Categories
     [Test]
     public async Task UpdateCategory_CategoryNotFound() =>
         await FluentActions.Awaiting(() => _apiClient.Patch(
-            $"category/{int.MaxValue}",
+            $"categories/{int.MaxValue}",
             new()
             {
                 Body = new UpdateCategoryRequest
@@ -725,7 +725,7 @@ internal class Categories
         context.ChangeTracker.Clear();
 
         ExceptionAssertions<RequestFailureException> exAssert = await FluentActions.Awaiting(() => _apiClient.Patch(
-            $"category/{toConflict.Id}",
+            $"categories/{toConflict.Id}",
             new()
             {
                 Body = new UpdateCategoryRequest()
@@ -776,7 +776,7 @@ internal class Categories
         context.ChangeTracker.Clear();
 
         await FluentActions.Awaiting(() => _apiClient.Patch(
-            $"category/{toNotConflict.Id}",
+            $"categories/{toNotConflict.Id}",
             new()
             {
                 Body = new UpdateCategoryRequest()
@@ -831,7 +831,7 @@ internal class Categories
         context.ChangeTracker.Clear();
 
         await FluentActions.Awaiting(() => _apiClient.Patch(
-            $"category/{toNotConflict.Id}",
+            $"categories/{toNotConflict.Id}",
             new()
             {
                 Body = new UpdateCategoryRequest()
@@ -876,7 +876,7 @@ internal class Categories
         }
 
         ExceptionAssertions<RequestFailureException> exAssert = await FluentActions.Awaiting(() => _apiClient.Patch(
-            $"category/{cat.Id}",
+            $"categories/{cat.Id}",
             new()
             {
                 Body = updateRequest,
@@ -921,7 +921,7 @@ internal class Categories
         context.ChangeTracker.Clear();
 
         await FluentActions.Awaiting(() => _apiClient.Patch(
-            $"category/{cat.Id}",
+            $"categories/{cat.Id}",
             new()
             {
                 Body = new
@@ -954,7 +954,7 @@ internal class Categories
         context.ChangeTracker.Clear();
 
         HttpResponseMessage response = await _apiClient.Delete(
-            $"/category/{cat.Id}",
+            $"/categories/{cat.Id}",
             new()
             {
                 Jwt = _jwt
@@ -990,7 +990,7 @@ internal class Categories
         context.ChangeTracker.Clear();
 
         await FluentActions.Awaiting(() => _apiClient.Delete(
-            $"category/{cat.Id}",
+            $"categories/{cat.Id}",
             new() { }
         )).Should().ThrowAsync<RequestFailureException>().Where(e => e.Response.StatusCode == HttpStatusCode.Unauthorized);
 
@@ -1039,7 +1039,7 @@ internal class Categories
         context.ChangeTracker.Clear();
 
         await FluentActions.Awaiting(() => _apiClient.Delete(
-            $"/category/{cat.Id}",
+            $"/categories/{cat.Id}",
             new()
             {
                 Jwt = res.Token
@@ -1054,7 +1054,7 @@ internal class Categories
     public async Task DeleteCategory_NotFound()
     {
         ExceptionAssertions<RequestFailureException> exAssert = await FluentActions.Awaiting(() => _apiClient.Delete(
-            $"/category/{int.MaxValue}",
+            $"/categories/{int.MaxValue}",
             new()
             {
                 Jwt = _jwt,
@@ -1086,7 +1086,7 @@ internal class Categories
         context.ChangeTracker.Clear();
 
         ExceptionAssertions<RequestFailureException> exAssert = await FluentActions.Awaiting(() => _apiClient.Delete(
-            $"/category/{cat.Id}",
+            $"/categories/{cat.Id}",
             new()
             {
                 Jwt = _jwt,

--- a/LeaderboardBackend.Test/Leaderboards.cs
+++ b/LeaderboardBackend.Test/Leaderboards.cs
@@ -174,6 +174,7 @@ public class Leaderboards
     [TestCase("Super Mario Bros.", "super-mario-bros.")]
     [TestCase("Super Mario Bros.", "1985-nintendo-nes-famicom-fds-gbc-gba-gcn-wiivc-3dsvc-wiiuvc-super-marios-bros-best-game")]
     [TestCase("Super Mario Bros.", "スーパーマリオブラザーズ")]
+    [TestCase("140", "140")]
     public async Task CreateLeaderboard_BadData(string name, string slug)
     {
         CreateLeaderboardRequest req = new()
@@ -912,6 +913,7 @@ public class Leaderboards
     )]
     [TestCase("The Legendary Starfy", "伝説のスタフィー", "densetsu-no-stafy", "デンセツノスタフィー")]
     [TestCase("Resident Evil", "", "resident-evil", null)]
+    [TestCase("Ten Million", "10000000", "ten-million", "10000000")]
     public async Task UpdateLeaderboard_BadData(string oldName, string? newName, string oldSlug, string? newSlug)
     {
         ApplicationContext context = _factory.Services.CreateScope().ServiceProvider.GetRequiredService<ApplicationContext>();

--- a/LeaderboardBackend.Test/Runs.cs
+++ b/LeaderboardBackend.Test/Runs.cs
@@ -97,7 +97,7 @@ namespace LeaderboardBackend.Test
             await context.Entry(run).Reference(r => r.User).LoadAsync();
 
             TimedRunViewModel retrieved = await _apiClient.Get<TimedRunViewModel>(
-                $"/api/run/{run.Id.ToUrlSafeBase64String()}",
+                $"/api/runs/{run.Id.ToUrlSafeBase64String()}",
                 new() { }
             );
 
@@ -109,7 +109,7 @@ namespace LeaderboardBackend.Test
         public async Task GetRun_NotFound(string id) =>
             await FluentActions.Awaiting(() =>
                 _apiClient.Get<RunViewModel>(
-                $"/api/run/{id}",
+                $"/api/runs/{id}",
                 new() { }
             )).Should()
             .ThrowAsync<RequestFailureException>()
@@ -160,23 +160,23 @@ namespace LeaderboardBackend.Test
                 await context.Entry(run).Reference(r => r.User).LoadAsync();
             }
 
-            ListView<TimedRunViewModel> returned = await _apiClient.Get<ListView<TimedRunViewModel>>($"/api/category/{_categoryId}/runs?limit=9999999", new());
+            ListView<TimedRunViewModel> returned = await _apiClient.Get<ListView<TimedRunViewModel>>($"/api/categories/{_categoryId}/runs?limit=9999999", new());
             returned.Data.Should().BeEquivalentTo(runs.Take(2).Select(RunViewModel.MapFrom));
             returned.Total.Should().Be(2);
 
-            ListView<TimedRunViewModel> returned2 = await _apiClient.Get<ListView<TimedRunViewModel>>($"/api/category/{_categoryId}/runs?status=published&limit=1024", new());
+            ListView<TimedRunViewModel> returned2 = await _apiClient.Get<ListView<TimedRunViewModel>>($"/api/categories/{_categoryId}/runs?status=published&limit=1024", new());
             returned2.Data.Should().BeEquivalentTo(runs.Take(2).Select(RunViewModel.MapFrom));
             returned2.Total.Should().Be(2);
 
-            ListView<TimedRunViewModel> returned3 = await _apiClient.Get<ListView<TimedRunViewModel>>($"/api/category/{_categoryId}/runs?status=any&limit=1024", new());
+            ListView<TimedRunViewModel> returned3 = await _apiClient.Get<ListView<TimedRunViewModel>>($"/api/categories/{_categoryId}/runs?status=any&limit=1024", new());
             returned3.Data.Should().BeEquivalentTo(new Run[] { runs[0], runs[2], runs[1] }.Select(RunViewModel.MapFrom), config => config.WithStrictOrdering());
             returned3.Total.Should().Be(3);
 
-            ListView<TimedRunViewModel> returned4 = await _apiClient.Get<ListView<TimedRunViewModel>>($"/api/category/{_categoryId}/runs?limit=1", new());
+            ListView<TimedRunViewModel> returned4 = await _apiClient.Get<ListView<TimedRunViewModel>>($"/api/categories/{_categoryId}/runs?limit=1", new());
             returned4.Data.Single().Should().BeEquivalentTo(RunViewModel.MapFrom(runs[0]));
             returned4.Total.Should().Be(2);
 
-            ListView<TimedRunViewModel> returned5 = await _apiClient.Get<ListView<TimedRunViewModel>>($"/api/category/{_categoryId}/runs?limit=1&status=any&offset=1", new());
+            ListView<TimedRunViewModel> returned5 = await _apiClient.Get<ListView<TimedRunViewModel>>($"/api/categories/{_categoryId}/runs?limit=1&status=any&offset=1", new());
             returned5.Data.Single().Should().BeEquivalentTo(RunViewModel.MapFrom(runs[2]));
             returned5.Total.Should().Be(3);
         }
@@ -186,7 +186,7 @@ namespace LeaderboardBackend.Test
         public async Task GetRunsForCategory_BadPageData(int limit, int offset) =>
             await _apiClient.Awaiting(
                 a => a.Get<RunViewModel>(
-                    $"/api/category/{_categoryId}/runs?limit={limit}&offset={offset}",
+                    $"/api/categories/{_categoryId}/runs?limit={limit}&offset={offset}",
                     new()
                 )
             ).Should()
@@ -198,7 +198,7 @@ namespace LeaderboardBackend.Test
         {
             ExceptionAssertions<RequestFailureException> exAssert = await _apiClient.Awaiting(
                 a => a.Get<RunViewModel>(
-                    "/api/category/0/runs",
+                    "/api/categories/0/runs",
                     new()
                 )
             ).Should()
@@ -235,7 +235,7 @@ namespace LeaderboardBackend.Test
             LoginResponse login = await _apiClient.LoginUser($"testuser.createrun.{role}@example.com", "P4ssword");
 
             TimedRunViewModel created = await _apiClient.Post<TimedRunViewModel>(
-                $"/category/{_categoryId}/runs/create",
+                $"/categories/{_categoryId}/runs",
                 new()
                 {
                     Body = new
@@ -250,7 +250,7 @@ namespace LeaderboardBackend.Test
             );
 
             TimedRunViewModel retrieved = await _apiClient.Get<TimedRunViewModel>(
-                $"/api/run/{created.Id.ToUrlSafeBase64String()}",
+                $"/api/runs/{created.Id.ToUrlSafeBase64String()}",
                 new() { }
             );
 
@@ -269,7 +269,7 @@ namespace LeaderboardBackend.Test
         [Test]
         public async Task CreateRun_Unauthenticated() =>
             await _apiClient.Awaiting(a => a.Post<RunViewModel>(
-                $"/category/{_categoryId}/runs/create",
+                $"/categories/{_categoryId}/runs",
                 new()
                 {
                     Body = new
@@ -308,7 +308,7 @@ namespace LeaderboardBackend.Test
             await context.SaveChangesAsync();
 
             ExceptionAssertions<RequestFailureException> exAssert = await _apiClient.Awaiting(a => a.Post<RunViewModel>(
-                $"/category/{_categoryId}/runs/create",
+                $"/categories/{_categoryId}/runs",
                 new()
                 {
                     Body = new
@@ -328,7 +328,7 @@ namespace LeaderboardBackend.Test
         public async Task CreateRun_CategoryNotFound()
         {
             ExceptionAssertions<RequestFailureException> exAssert = await _apiClient.Awaiting(a => a.Post<RunViewModel>(
-                "/category/0/runs/create",
+                "/categories/0/runs",
                 new()
                 {
                     Body = new
@@ -369,7 +369,7 @@ namespace LeaderboardBackend.Test
             await context.SaveChangesAsync();
 
             ExceptionAssertions<RequestFailureException> exAssert = await _apiClient.Awaiting(a => a.Post<RunViewModel>(
-                $"/category/{deleted.Id}/runs/create",
+                $"/categories/{deleted.Id}/runs",
                 new()
                 {
                     Body = new
@@ -398,7 +398,7 @@ namespace LeaderboardBackend.Test
         public async Task CreateRun_BadData(string? playedOn, string info, string? time)
         {
             ExceptionAssertions<RequestFailureException> exAssert = await _apiClient.Awaiting(a => a.Post<RunViewModel>(
-                $"/category/{_categoryId}/runs/create",
+                $"/categories/{_categoryId}/runs",
                 new()
                 {
                     Body = new
@@ -417,7 +417,7 @@ namespace LeaderboardBackend.Test
         public async Task GetCategoryForRun_OK()
         {
             TimedRunViewModel createdRun = await _apiClient.Post<TimedRunViewModel>(
-                $"/category/{_categoryId}/runs/create",
+                $"/categories/{_categoryId}/runs",
                 new()
                 {
                     Body = new
@@ -432,7 +432,7 @@ namespace LeaderboardBackend.Test
             );
 
             CategoryViewModel category = await _apiClient.Get<CategoryViewModel>(
-                $"api/run/{createdRun.Id.ToUrlSafeBase64String()}/category",
+                $"api/runs/{createdRun.Id.ToUrlSafeBase64String()}/category",
                 new() { Jwt = _jwt }
             );
 
@@ -460,7 +460,7 @@ namespace LeaderboardBackend.Test
             context.ChangeTracker.Clear();
 
             HttpResponseMessage response = await _apiClient.Patch(
-                $"/run/{run.Id.ToUrlSafeBase64String()}",
+                $"/runs/{run.Id.ToUrlSafeBase64String()}",
                 new()
                 {
                     Body = new
@@ -517,7 +517,7 @@ namespace LeaderboardBackend.Test
                 "updaterun.ok@example.com", "Passw0rd");
 
             HttpResponseMessage userResponse = await _apiClient.Patch(
-                $"/run/{run.Id.ToUrlSafeBase64String()}",
+                $"/runs/{run.Id.ToUrlSafeBase64String()}",
                 new()
                 {
                     Body = new
@@ -556,7 +556,7 @@ namespace LeaderboardBackend.Test
             context.ChangeTracker.Clear();
 
             await _apiClient.Awaiting(a => a.Patch(
-                $"run/{created.Id}",
+                $"runs/{created.Id}",
                 new()
                 {
                     Body = new
@@ -610,7 +610,7 @@ namespace LeaderboardBackend.Test
             await context.SaveChangesAsync();
 
             await _apiClient.Awaiting(a => a.Patch(
-                $"run/{created.Id.ToUrlSafeBase64String()}",
+                $"runs/{created.Id.ToUrlSafeBase64String()}",
                 new()
                 {
                     Body = new
@@ -662,7 +662,7 @@ namespace LeaderboardBackend.Test
             LoginResponse res = await _apiClient.LoginUser(registerRequest.Email, registerRequest.Password);
 
             ExceptionAssertions<RequestFailureException> exAssert = await _apiClient.Awaiting(a => a.Patch(
-                $"run/{created.Id.ToUrlSafeBase64String()}",
+                $"runs/{created.Id.ToUrlSafeBase64String()}",
                 new()
                 {
                     Body = new
@@ -682,7 +682,7 @@ namespace LeaderboardBackend.Test
         [Test]
         public async Task UpdateRun_NotFound() =>
             await _apiClient.Awaiting(a => a.Patch(
-                $"run/{Guid.Empty.ToUrlSafeBase64String()}",
+                $"runs/{Guid.Empty.ToUrlSafeBase64String()}",
                 new()
                 {
                     Body = new
@@ -731,7 +731,7 @@ namespace LeaderboardBackend.Test
 
             LoginResponse res = await _apiClient.LoginUser(registerRequest.Email, registerRequest.Password);
             ExceptionAssertions<RequestFailureException> exAssert = await _apiClient.Awaiting(a => a.Patch(
-                $"run/{created.Id.ToUrlSafeBase64String()}",
+                $"runs/{created.Id.ToUrlSafeBase64String()}",
                 new()
                 {
                     Body = new
@@ -799,7 +799,7 @@ namespace LeaderboardBackend.Test
 
             LoginResponse res = await _apiClient.LoginUser(registerRequest.Email, registerRequest.Password);
             ExceptionAssertions<RequestFailureException> exAssert = await _apiClient.Awaiting(a => a.Patch(
-                $"run/{created.Id.ToUrlSafeBase64String()}",
+                $"runs/{created.Id.ToUrlSafeBase64String()}",
                 new()
                 {
                     Body = new
@@ -836,7 +836,7 @@ namespace LeaderboardBackend.Test
 
             ExceptionAssertions<RequestFailureException> exAssert = await _apiClient.Awaiting(
                 a => a.Patch(
-                    $"run/{created.Id.ToUrlSafeBase64String()}",
+                    $"runs/{created.Id.ToUrlSafeBase64String()}",
                     new()
                     {
                         Body = new
@@ -872,7 +872,7 @@ namespace LeaderboardBackend.Test
             context.ChangeTracker.Clear();
 
             HttpResponseMessage message = await _apiClient.Delete(
-                $"run/{created.Id.ToUrlSafeBase64String()}",
+                $"runs/{created.Id.ToUrlSafeBase64String()}",
                 new()
                 {
                     Jwt = _jwt,
@@ -906,7 +906,7 @@ namespace LeaderboardBackend.Test
             context.ChangeTracker.Clear();
 
             await _apiClient.Awaiting(a => a.Delete(
-                $"run/{run.Id.ToUrlSafeBase64String()}",
+                $"runs/{run.Id.ToUrlSafeBase64String()}",
                 new() { }
             )).Should().ThrowAsync<RequestFailureException>().Where(e => e.Response.StatusCode == HttpStatusCode.Unauthorized);
 
@@ -953,7 +953,7 @@ namespace LeaderboardBackend.Test
             context.ChangeTracker.Clear();
 
             await _apiClient.Awaiting(a => a.Delete(
-                $"run/{run.Id.ToUrlSafeBase64String()}",
+                $"runs/{run.Id.ToUrlSafeBase64String()}",
                 new() { Jwt = res.Token }
             )).Should().ThrowAsync<RequestFailureException>().Where(e => e.Response.StatusCode == HttpStatusCode.Forbidden);
 
@@ -965,7 +965,7 @@ namespace LeaderboardBackend.Test
         public async Task DeleteRun_NotFound()
         {
             ExceptionAssertions<RequestFailureException> exAssert = await _apiClient.Awaiting(a => a.Delete(
-                $"run/{Guid.Empty.ToUrlSafeBase64String()}",
+                $"runs/{Guid.Empty.ToUrlSafeBase64String()}",
                 new()
                 {
                     Jwt = _jwt,
@@ -998,7 +998,7 @@ namespace LeaderboardBackend.Test
             context.ChangeTracker.Clear();
 
             ExceptionAssertions<RequestFailureException> exAssert = await _apiClient.Awaiting(a => a.Delete(
-                $"run/{run.Id.ToUrlSafeBase64String()}",
+                $"runs/{run.Id.ToUrlSafeBase64String()}",
                 new()
                 {
                     Jwt = _jwt,

--- a/LeaderboardBackend/Controllers/CategoriesController.cs
+++ b/LeaderboardBackend/Controllers/CategoriesController.cs
@@ -15,7 +15,7 @@ namespace LeaderboardBackend.Controllers;
 public class CategoriesController(ICategoryService categoryService) : ApiController
 {
     [AllowAnonymous]
-    [HttpGet("api/category/{id:long}")]
+    [HttpGet("api/categories/{id:long}")]
     [SwaggerOperation("Gets a Category by its ID.", OperationId = "getCategory")]
     [SwaggerResponse(200)]
     [SwaggerResponse(404)]
@@ -32,13 +32,13 @@ public class CategoriesController(ICategoryService categoryService) : ApiControl
     }
 
     [AllowAnonymous]
-    [HttpGet("api/leaderboard/{id:long}/category")]
+    [HttpGet("api/leaderboards/{id:long}/categories/{slug}")]
     [SwaggerOperation("Gets a Category of Leaderboard `id` by its slug. Will not return deleted Categories.", OperationId = "getCategoryBySlug")]
     [SwaggerResponse(200)]
     [SwaggerResponse(404, "The Category either doesn't exist for the Leaderboard, or it has been deleted.", typeof(ProblemDetails))]
     public async Task<ActionResult<CategoryViewModel>> GetCategoryBySlug(
         [FromRoute] long id,
-        [FromQuery, SwaggerParameter(Required = true)] string slug
+        [FromRoute] string slug
     )
     {
         Category? category = await categoryService.GetCategoryBySlug(id, slug);
@@ -52,7 +52,7 @@ public class CategoriesController(ICategoryService categoryService) : ApiControl
     }
 
     [AllowAnonymous]
-    [HttpGet("api/leaderboard/{id:long}/categories")]
+    [HttpGet("api/leaderboards/{id:long}/categories")]
     [Paginated]
     [SwaggerOperation("Gets all Categories of Leaderboard `id`.", OperationId = "getCategoriesForLeaderboard")]
     [SwaggerResponse(200)]
@@ -77,7 +77,7 @@ public class CategoriesController(ICategoryService categoryService) : ApiControl
     }
 
     [Authorize(Policy = UserTypes.ADMINISTRATOR)]
-    [HttpPost("leaderboard/{id:long}/categories/create")]
+    [HttpPost("leaderboards/{id:long}/categories")]
     [SwaggerOperation("Creates a new Category for a Leaderboard with ID `id`. This request is restricted to Administrators.", OperationId = "createCategory")]
     [SwaggerResponse(201)]
     [SwaggerResponse(401)]
@@ -114,7 +114,7 @@ public class CategoriesController(ICategoryService categoryService) : ApiControl
     }
 
     [Authorize(Policy = UserTypes.ADMINISTRATOR)]
-    [HttpPatch("category/{id:long}")]
+    [HttpPatch("categories/{id:long}")]
     [SwaggerOperation(
         "Updates a category with the specified new fields. This request is restricted to administrators. " +
         "Note: `type` cannot be updated. " +
@@ -152,7 +152,7 @@ public class CategoriesController(ICategoryService categoryService) : ApiControl
     }
 
     [Authorize(Policy = UserTypes.ADMINISTRATOR)]
-    [HttpDelete("category/{id:long}")]
+    [HttpDelete("categories/{id:long}")]
     [SwaggerOperation("Deletes a Category. This request is restricted to Administrators.", OperationId = "deleteCategory")]
     [SwaggerResponse(204)]
     [SwaggerResponse(401)]

--- a/LeaderboardBackend/Controllers/CategoriesController.cs
+++ b/LeaderboardBackend/Controllers/CategoriesController.cs
@@ -180,36 +180,4 @@ public class CategoriesController(ICategoryService categoryService) : ApiControl
             )
         );
     }
-
-    [Authorize(Policy = UserTypes.ADMINISTRATOR)]
-    [HttpPut("category/{id:long}/restore")]
-    [SwaggerOperation("Restores a deleted Category.", OperationId = "restoreCategory")]
-    [SwaggerResponse(200, "The restored `Category`s view model.", typeof(CategoryViewModel))]
-    [SwaggerResponse(401)]
-    [SwaggerResponse(403, "The requesting `User` is unauthorized to restore `Category`s.")]
-    [SwaggerResponse(404, "The `Category` was not found, or it wasn't deleted in the first place. Includes a field, `title`, which will be \"Not Found\" in the former case, and \"Not Deleted\" in the latter.", typeof(ProblemDetails))]
-    [SwaggerResponse(409, "Another `Category` with the same slug has been created since, and therefore can't be restored. Said `Category` will be returned in the `conflicting` field in the response.", typeof(ConflictDetails<CategoryViewModel>))]
-    public async Task<ActionResult<CategoryViewModel>> RestoreCategory(
-        [FromRoute] long id
-    )
-    {
-        RestoreResult<Category> r = await categoryService.RestoreCategory(id);
-
-        return r.Match<ActionResult<CategoryViewModel>>(
-            category => Ok(CategoryViewModel.MapFrom(category)),
-            notFound => NotFound(),
-            neverDeleted => Problem(
-                null,
-                null,
-                404,
-                "Not Deleted"
-            ),
-            conflict =>
-            {
-                ProblemDetails problemDetails = ProblemDetailsFactory.CreateProblemDetails(HttpContext, StatusCodes.Status409Conflict);
-                problemDetails.Extensions.Add("conflicting", CategoryViewModel.MapFrom(conflict.Conflicting));
-                return Conflict(problemDetails);
-            }
-        );
-    }
 }

--- a/LeaderboardBackend/Controllers/LeaderboardsController.cs
+++ b/LeaderboardBackend/Controllers/LeaderboardsController.cs
@@ -129,38 +129,6 @@ public class LeaderboardsController(
     }
 
     [Authorize(Policy = UserTypes.ADMINISTRATOR)]
-    [HttpPut("leaderboard/{id:long}/restore")]
-    [SwaggerOperation("Restores a deleted leaderboard.", OperationId = "restoreLeaderboard")]
-    [SwaggerResponse(200, "The restored `Leaderboard`s view model.", typeof(LeaderboardViewModel))]
-    [SwaggerResponse(401)]
-    [SwaggerResponse(403, "The requesting `User` is unauthorized to restore `Leaderboard`s.")]
-    [SwaggerResponse(404, "The `Leaderboard` was not found, or it wasn't deleted in the first place. Includes a field, `title`, which will be \"Not Found\" in the former case, and \"Not Deleted\" in the latter.", typeof(ProblemDetails))]
-    [SwaggerResponse(409, "Another `Leaderboard` with the same slug has been created since and will be returned in the `conflicting` field, and therefore can't be restored.", typeof(ConflictDetails<LeaderboardViewModel>))]
-    public async Task<ActionResult<LeaderboardViewModel>> RestoreLeaderboard(
-        [FromRoute] long id
-    )
-    {
-        RestoreResult<Leaderboard> r = await leaderboardService.RestoreLeaderboard(id);
-
-        return r.Match<ActionResult<LeaderboardViewModel>>(
-            board => Ok(LeaderboardViewModel.MapFrom(board)),
-            notFound => NotFound(),
-            neverDeleted => Problem(
-                null,
-                null,
-                404,
-                "Not Deleted"
-            ),
-            conflict =>
-            {
-                ProblemDetails problemDetails = ProblemDetailsFactory.CreateProblemDetails(HttpContext, StatusCodes.Status409Conflict);
-                problemDetails.Extensions.Add("conflicting", LeaderboardViewModel.MapFrom(conflict.Conflicting));
-                return Conflict(problemDetails);
-            }
-        );
-    }
-
-    [Authorize(Policy = UserTypes.ADMINISTRATOR)]
     [HttpDelete("leaderboard/{id:long}")]
     [SwaggerOperation("Deletes a leaderboard. This request is restricted to Administrators.", OperationId = "deleteLeaderboard")]
     [SwaggerResponse(204)]

--- a/LeaderboardBackend/Controllers/LeaderboardsController.cs
+++ b/LeaderboardBackend/Controllers/LeaderboardsController.cs
@@ -17,7 +17,7 @@ public class LeaderboardsController(
 ) : ApiController
 {
     [AllowAnonymous]
-    [HttpGet("api/leaderboard/{id:long}")]
+    [HttpGet("api/leaderboards/{id:long}")]
     [SwaggerOperation("Gets a leaderboard by its ID.", OperationId = "getLeaderboard")]
     [SwaggerResponse(200)]
     [SwaggerResponse(404)]
@@ -34,11 +34,11 @@ public class LeaderboardsController(
     }
 
     [AllowAnonymous]
-    [HttpGet("api/leaderboard")]
+    [HttpGet("api/leaderboards/{slug}")]
     [SwaggerOperation("Gets a leaderboard by its slug. Will not return deleted boards.", OperationId = "getLeaderboardBySlug")]
     [SwaggerResponse(200)]
     [SwaggerResponse(404)]
-    public async Task<ActionResult<LeaderboardViewModel>> GetLeaderboardBySlug([FromQuery, SwaggerParameter(Required = true)] string slug)
+    public async Task<ActionResult<LeaderboardViewModel>> GetLeaderboardBySlug([FromRoute] string slug)
     {
         Leaderboard? leaderboard = await leaderboardService.GetLeaderboardBySlug(slug);
 
@@ -100,7 +100,7 @@ public class LeaderboardsController(
     }
 
     [Authorize(Policy = UserTypes.ADMINISTRATOR)]
-    [HttpPost("leaderboards/create")]
+    [HttpPost("leaderboards")]
     [SwaggerOperation("Creates a new leaderboard. This request is restricted to Administrators.", OperationId = "createLeaderboard")]
     [SwaggerResponse(201)]
     [SwaggerResponse(401)]
@@ -129,7 +129,7 @@ public class LeaderboardsController(
     }
 
     [Authorize(Policy = UserTypes.ADMINISTRATOR)]
-    [HttpDelete("leaderboard/{id:long}")]
+    [HttpDelete("leaderboards/{id:long}")]
     [SwaggerOperation("Deletes a leaderboard. This request is restricted to Administrators.", OperationId = "deleteLeaderboard")]
     [SwaggerResponse(204)]
     [SwaggerResponse(401)]
@@ -159,7 +159,7 @@ public class LeaderboardsController(
     }
 
     [Authorize(Policy = UserTypes.ADMINISTRATOR)]
-    [HttpPatch("/leaderboard/{id:long}")]
+    [HttpPatch("/leaderboards/{id:long}")]
     [SwaggerOperation(
         "Updates a leaderboard with the specified new fields. This request is restricted to administrators. " +
         "This operation is atomic; if an error occurs, the leaderboard will not be updated. " +

--- a/LeaderboardBackend/Controllers/RunsController.cs
+++ b/LeaderboardBackend/Controllers/RunsController.cs
@@ -19,7 +19,7 @@ public class RunsController(
     ) : ApiController
 {
     [AllowAnonymous]
-    [HttpGet("api/run/{id}")]
+    [HttpGet("api/runs/{id}")]
     [SwaggerOperation("Gets a Run by its ID.", OperationId = "getRun")]
     [SwaggerResponse(200)]
     [SwaggerResponse(404, "The Run with ID `id` could not be found.", typeof(ProblemDetails))]
@@ -36,7 +36,7 @@ public class RunsController(
     }
 
     [Authorize]
-    [HttpPost("/category/{id:long}/runs/create")]
+    [HttpPost("/categories/{id:long}/runs")]
     [SwaggerOperation("Creates a new Run for a Category with ID `id`. This request is restricted to confirmed Users and Administrators.", OperationId = "createRun")]
     [SwaggerResponse(201)]
     [SwaggerResponse(401, "The client is not logged in.", typeof(ProblemDetails))]
@@ -101,7 +101,7 @@ public class RunsController(
     }
 
     [AllowAnonymous]
-    [HttpGet("/api/category/{id:long}/runs")]
+    [HttpGet("/api/categories/{id:long}/runs")]
     [Paginated]
     [SwaggerOperation("Gets the Runs for a Category.", OperationId = "getRunsForCategory")]
     [SwaggerResponse(200)]
@@ -131,7 +131,7 @@ public class RunsController(
     }
 
     [AllowAnonymous]
-    [HttpGet("/api/run/{id}/category")]
+    [HttpGet("/api/runs/{id}/category")]
     [SwaggerOperation("Gets the category a run belongs to.", OperationId = "getRunCategory")]
     [SwaggerResponse(200)]
     [SwaggerResponse(404)]
@@ -156,7 +156,7 @@ public class RunsController(
 
     // TODO: Replace UserTypes with UserRole, i.e. reconfigure authZ policy infra
     [Authorize]
-    [HttpPatch("run/{id}")]
+    [HttpPatch("runs/{id}")]
     [SwaggerOperation(
         "Updates a run with the specified new fields. This request is restricted to administrators " +
         "or users updating their own runs. " +
@@ -167,7 +167,13 @@ public class RunsController(
     )]
     [SwaggerResponse(204)]
     [SwaggerResponse(401)]
-    [SwaggerResponse(403, "The user attempted to update another user's run, or the user is banned or not yet confirmed.", Type = typeof(ProblemDetails))]
+    [SwaggerResponse(
+        403,
+        "The user attempted to update another user's run, " +
+        "the user is banned or not yet confirmed, " +
+        "or the user attempted to change the status of a run.",
+        Type = typeof(ProblemDetails)
+    )]
     [SwaggerResponse(404, "The Run with ID `id` could not be found, or has been deleted. Read `title` for more information.", Type = typeof(ProblemDetails))]
     [SwaggerResponse(
         422,
@@ -243,7 +249,7 @@ public class RunsController(
 
     // TODO: To replace UserTypes with UserRole
     [Authorize(Policy = UserTypes.ADMINISTRATOR)]
-    [HttpDelete("/run/{id}")]
+    [HttpDelete("/runs/{id}")]
     [SwaggerOperation("Deletes a Run.", OperationId = "deleteRun")]
     [SwaggerResponse(204)]
     [SwaggerResponse(401)]

--- a/LeaderboardBackend/Controllers/UsersController.cs
+++ b/LeaderboardBackend/Controllers/UsersController.cs
@@ -10,7 +10,7 @@ namespace LeaderboardBackend.Controllers;
 public class UsersController(IUserService userService) : ApiController
 {
     [AllowAnonymous]
-    [HttpGet("api/user/{id}")]
+    [HttpGet("api/users/{id}")]
     [SwaggerOperation("Gets a User by their ID.", OperationId = "getUser")]
     [SwaggerResponse(200, "The `User` was found and returned successfully.")]
     [SwaggerResponse(404, "No `User` with the requested ID could be found.")]
@@ -29,7 +29,7 @@ public class UsersController(IUserService userService) : ApiController
     }
 
     [Authorize]
-    [HttpGet("user/me")]
+    [HttpGet("users/me")]
     [SwaggerOperation(
         "Gets the currently logged-in User.",
         """

--- a/LeaderboardBackend/Models/Entities/Leaderboard.cs
+++ b/LeaderboardBackend/Models/Entities/Leaderboard.cs
@@ -62,7 +62,7 @@ public class Leaderboard : IHasUpdateTimestamp, IHasDeletionTimestamp
     /// </summary>
     /// <example>foo-bar</example>
     [StringLength(80, MinimumLength = 2)]
-    [RegularExpression(SlugRule.REGEX)]
+    [RegularExpression(LeaderboardSlugRule.REGEX)]
     public required string Slug { get; set; }
 
     /// <summary>

--- a/LeaderboardBackend/Models/Requests/CategoryRequests.cs
+++ b/LeaderboardBackend/Models/Requests/CategoryRequests.cs
@@ -46,21 +46,24 @@ public record CreateCategoryRequest
 
 public record UpdateCategoryRequest
 {
-    /// <inheritdoc cref="Entities.Category.Name" />
+    /// <inheritdoc cref="Category.Name" />
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string Name { get; set; }
 
-    /// <inheritdoc cref="Entities.Category.Slug" />
+    /// <inheritdoc cref="Category.Slug" />
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string Slug { get; set; }
 
-    /// <inheritdoc cref="Entities.Category.Info" />
+    /// <inheritdoc cref="Category.Info" />
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string Info { get; set; }
 
-    /// <inheritdoc cref="Entities.Category.SortDirection" />
+    /// <inheritdoc cref="Category.SortDirection" />
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public SortDirection? SortDirection { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Status? Status { get; set; }
 }
 
 public class CreateCategoryRequestValidator : AbstractValidator<CreateCategoryRequest>
@@ -82,9 +85,11 @@ public class UpdateCategoryRequestValidator : AbstractValidator<UpdateCategoryRe
             ucr => ucr.Info is not null ||
             ucr.Name is not null ||
             ucr.Slug is not null ||
-            ucr.SortDirection is not null);
+            ucr.SortDirection is not null ||
+            ucr.Status is not null);
         RuleFor(x => x.Slug).Slug();
         RuleFor(x => x.Name).MinimumLength(1);
         RuleFor(x => x.SortDirection).IsInEnum();
+        RuleFor(x => x.Status).IsInEnum();
     }
 }

--- a/LeaderboardBackend/Models/Requests/LeaderboardRequests.cs
+++ b/LeaderboardBackend/Models/Requests/LeaderboardRequests.cs
@@ -47,15 +47,19 @@ public record UpdateLeaderboardRequest
     /// <inheritdoc cref="Entities.Leaderboard.Info" />
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string Info { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Status? Status { get; set; }
 }
 
 public class UpdateLeaderboardRequestValidator : AbstractValidator<UpdateLeaderboardRequest>
 {
     public UpdateLeaderboardRequestValidator()
     {
-        RuleFor(x => x).Must(ulr => ulr.Info is not null || ulr.Name is not null || ulr.Slug is not null);
+        RuleFor(x => x).Must(ulr => ulr.Info is not null || ulr.Name is not null || ulr.Slug is not null || ulr.Status is not null);
         RuleFor(x => x.Slug).Slug();
         RuleFor(x => x.Name).MinimumLength(1);
+        RuleFor(x => x.Status).IsInEnum();
     }
 }
 

--- a/LeaderboardBackend/Models/Requests/LeaderboardRequests.cs
+++ b/LeaderboardBackend/Models/Requests/LeaderboardRequests.cs
@@ -57,7 +57,7 @@ public class UpdateLeaderboardRequestValidator : AbstractValidator<UpdateLeaderb
     public UpdateLeaderboardRequestValidator()
     {
         RuleFor(x => x).Must(ulr => ulr.Info is not null || ulr.Name is not null || ulr.Slug is not null || ulr.Status is not null);
-        RuleFor(x => x.Slug).Slug();
+        RuleFor(x => x.Slug).LeaderboardSlug();
         RuleFor(x => x.Name).MinimumLength(1);
         RuleFor(x => x.Status).IsInEnum();
     }
@@ -68,6 +68,6 @@ public class CreateLeaderboardRequestValidator : AbstractValidator<CreateLeaderb
     public CreateLeaderboardRequestValidator()
     {
         RuleFor(x => x.Name).NotEmpty();
-        RuleFor(x => x.Slug).NotEmpty().Slug();
+        RuleFor(x => x.Slug).NotEmpty().LeaderboardSlug();
     }
 }

--- a/LeaderboardBackend/Models/Requests/RunRequests.cs
+++ b/LeaderboardBackend/Models/Requests/RunRequests.cs
@@ -74,6 +74,13 @@ public abstract record UpdateRunRequest
     /// <inheritdoc cref="CreateRunRequest.PlayedOn" />
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public LocalDate? PlayedOn { get; set; }
+
+    /// <remarks>
+    ///     The user must have admin privileges in order to update this property.
+    /// </remarks>
+    /// <seealso cref="ViewModels.RunViewModel.Status"/>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Status? Status { get; set; }
 }
 
 public record UpdateTimedRunRequest : UpdateRunRequest
@@ -101,18 +108,28 @@ public class UpdateRunRequestValidator : AbstractValidator<UpdateRunRequest>
 
 public class UpdateTimedRunRequestValidator : AbstractValidator<UpdateTimedRunRequest>
 {
-    public UpdateTimedRunRequestValidator() =>
+    public UpdateTimedRunRequestValidator()
+    {
         RuleFor(x => x).Must(
             utrr => utrr.Info is not null ||
             utrr.PlayedOn is not null ||
-            utrr.Time is not null);
+            utrr.Time is not null ||
+            utrr.Status is not null);
+
+        RuleFor(x => x.Status).IsInEnum();
+    }
 }
 
 public class UpdateScoredRunRequestValidator : AbstractValidator<UpdateScoredRunRequest>
 {
-    public UpdateScoredRunRequestValidator() =>
+    public UpdateScoredRunRequestValidator()
+    {
         RuleFor(x => x).Must(
             usrr => usrr.Info is not null ||
             usrr.PlayedOn is not null ||
-            usrr.Score is not null);
+            usrr.Score is not null ||
+            usrr.Status is not null);
+
+        RuleFor(x => x.Status).IsInEnum();
+    }
 }

--- a/LeaderboardBackend/Models/Validation/LeaderboardSlugRule.cs
+++ b/LeaderboardBackend/Models/Validation/LeaderboardSlugRule.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+
+namespace LeaderboardBackend.Models.Validation;
+
+public static class LeaderboardSlugRule
+{
+    public const string LEADERBOARD_SLUG_FORMAT = "SlugFormat";
+    public const string REGEX = @"^(?!([0-9]+)$)[a-zA-Z0-9\-_]*$";
+
+    public static IRuleBuilderOptions<T, string> LeaderboardSlug<T>(this IRuleBuilder<T, string> ruleBuilder)
+        => ruleBuilder
+            .Length(2, 80)
+                .WithErrorCode(LEADERBOARD_SLUG_FORMAT)
+            .Matches(REGEX)
+                .WithErrorCode(LEADERBOARD_SLUG_FORMAT)
+                .WithMessage("Invalid slug format.");
+}

--- a/LeaderboardBackend/Services/Impl/CategoryService.cs
+++ b/LeaderboardBackend/Services/Impl/CategoryService.cs
@@ -1,3 +1,4 @@
+using LeaderboardBackend.Models;
 using LeaderboardBackend.Models.Entities;
 using LeaderboardBackend.Models.Requests;
 using LeaderboardBackend.Result;
@@ -97,6 +98,27 @@ public class CategoryService(ApplicationContext applicationContext, IClock clock
         if (request.SortDirection is not null)
         {
             cat.SortDirection = (SortDirection)request.SortDirection;
+        }
+
+        switch (request.Status)
+        {
+            case null:
+                break;
+
+            case Status.Published:
+            {
+                cat.DeletedAt = null;
+                break;
+            }
+
+            case Status.Deleted:
+            {
+                cat.DeletedAt = clock.GetCurrentInstant();
+                break;
+            }
+
+            default:
+                throw new ArgumentException($"Invalid Status in request: {(int)request.Status}", nameof(request));
         }
 
         try

--- a/LeaderboardBackend/Services/Impl/LeaderboardService.cs
+++ b/LeaderboardBackend/Services/Impl/LeaderboardService.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using LeaderboardBackend.Models;
 using LeaderboardBackend.Models.Entities;
 using LeaderboardBackend.Models.Requests;
 using LeaderboardBackend.Result;
@@ -134,6 +135,29 @@ public class LeaderboardService(ApplicationContext applicationContext, IClock cl
         if (request.Slug is not null)
         {
             lb.Slug = request.Slug;
+        }
+
+        switch (request.Status)
+        {
+            case null:
+                break;
+
+            case Status.Published:
+            {
+                lb.DeletedAt = null;
+                break;
+            }
+
+            case Status.Deleted:
+            {
+                lb.DeletedAt = clock.GetCurrentInstant();
+                break;
+            }
+
+            default:
+            {
+                throw new ArgumentException($"Invalid Status in request: {(int)request.Status}", nameof(request));
+            }
         }
 
         try

--- a/LeaderboardBackend/Services/Impl/RunService.cs
+++ b/LeaderboardBackend/Services/Impl/RunService.cs
@@ -155,6 +155,11 @@ public class RunService(ApplicationContext applicationContext, IClock clock) : I
                     return new AlreadyDeleted(typeof(Leaderboard));
                 }
 
+                if (request.Status is not null)
+                {
+                    return new BadRole();
+                }
+
                 break;
             }
             case UserRole.Administrator:
@@ -171,6 +176,27 @@ public class RunService(ApplicationContext applicationContext, IClock clock) : I
         if (request.PlayedOn is not null)
         {
             run.PlayedOn = (LocalDate)request.PlayedOn;
+        }
+
+        switch (request.Status)
+        {
+            case null:
+                break;
+
+            case Status.Published:
+            {
+                run.DeletedAt = null;
+                break;
+            }
+
+            case Status.Deleted:
+            {
+                run.DeletedAt = clock.GetCurrentInstant();
+                break;
+            }
+
+            default:
+                throw new ArgumentException($"Invalid Status in request: {(int)request.Status}", nameof(request));
         }
 
         switch (request)

--- a/LeaderboardBackend/openapi.json
+++ b/LeaderboardBackend/openapi.json
@@ -356,7 +356,7 @@
         }
       }
     },
-    "/api/category/{id}": {
+    "/api/categories/{id}": {
       "get": {
         "tags": [
           "Categories"
@@ -404,7 +404,7 @@
         }
       }
     },
-    "/api/leaderboard/{id}/category": {
+    "/api/leaderboards/{id}/categories/{slug}": {
       "get": {
         "tags": [
           "Categories"
@@ -423,7 +423,7 @@
           },
           {
             "name": "slug",
-            "in": "query",
+            "in": "path",
             "required": true,
             "schema": {
               "type": "string"
@@ -467,7 +467,7 @@
         }
       }
     },
-    "/api/leaderboard/{id}/categories": {
+    "/api/leaderboards/{id}/categories": {
       "get": {
         "tags": [
           "Categories"
@@ -563,7 +563,7 @@
         }
       }
     },
-    "/leaderboard/{id}/categories/create": {
+    "/leaderboards/{id}/categories": {
       "post": {
         "tags": [
           "Categories"
@@ -659,7 +659,7 @@
         }
       }
     },
-    "/category/{id}": {
+    "/categories/{id}": {
       "patch": {
         "tags": [
           "Categories"
@@ -799,78 +799,7 @@
         }
       }
     },
-    "/category/{id}/restore": {
-      "put": {
-        "tags": [
-          "Categories"
-        ],
-        "summary": "Restores a deleted Category.",
-        "operationId": "restoreCategory",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "responses": {
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error"
-          },
-          "200": {
-            "description": "The restored `Category`s view model.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CategoryViewModel"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "The requesting `User` is unauthorized to restore `Category`s."
-          },
-          "404": {
-            "description": "The `Category` was not found, or it wasn't deleted in the first place. Includes a field, `title`, which will be \"Not Found\" in the former case, and \"Not Deleted\" in the latter.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Another `Category` with the same slug has been created since, and therefore can't be restored. Said `Category` will be returned in the `conflicting` field in the response.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CategoryViewModelConflictDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/leaderboard/{id}": {
+    "/api/leaderboards/{id}": {
       "get": {
         "tags": [
           "Leaderboards"
@@ -918,7 +847,7 @@
         }
       }
     },
-    "/api/leaderboard": {
+    "/api/leaderboards/{slug}": {
       "get": {
         "tags": [
           "Leaderboards"
@@ -928,7 +857,7 @@
         "parameters": [
           {
             "name": "slug",
-            "in": "query",
+            "in": "path",
             "required": true,
             "schema": {
               "type": "string"
@@ -1142,7 +1071,7 @@
         }
       }
     },
-    "/leaderboards/create": {
+    "/leaderboards": {
       "post": {
         "tags": [
           "Leaderboards"
@@ -1217,78 +1146,7 @@
         }
       }
     },
-    "/leaderboard/{id}/restore": {
-      "put": {
-        "tags": [
-          "Leaderboards"
-        ],
-        "summary": "Restores a deleted leaderboard.",
-        "operationId": "restoreLeaderboard",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "responses": {
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error"
-          },
-          "200": {
-            "description": "The restored `Leaderboard`s view model.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LeaderboardViewModel"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "The requesting `User` is unauthorized to restore `Leaderboard`s."
-          },
-          "404": {
-            "description": "The `Leaderboard` was not found, or it wasn't deleted in the first place. Includes a field, `title`, which will be \"Not Found\" in the former case, and \"Not Deleted\" in the latter.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Another `Leaderboard` with the same slug has been created since and will be returned in the `conflicting` field, and therefore can't be restored.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LeaderboardViewModelConflictDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/leaderboard/{id}": {
+    "/leaderboards/{id}": {
       "delete": {
         "tags": [
           "Leaderboards"
@@ -1410,7 +1268,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LeaderboardViewModel"
+                  "$ref": "#/components/schemas/LeaderboardViewModelConflictDetails"
                 }
               }
             }
@@ -1428,7 +1286,7 @@
         }
       }
     },
-    "/api/run/{id}": {
+    "/api/runs/{id}": {
       "get": {
         "tags": [
           "Runs"
@@ -1490,7 +1348,7 @@
         }
       }
     },
-    "/category/{id}/runs/create": {
+    "/categories/{id}/runs": {
       "post": {
         "tags": [
           "Runs"
@@ -1600,7 +1458,7 @@
         }
       }
     },
-    "/api/category/{id}/runs": {
+    "/api/categories/{id}/runs": {
       "get": {
         "tags": [
           "Runs"
@@ -1696,7 +1554,7 @@
         }
       }
     },
-    "/api/run/{id}/category": {
+    "/api/runs/{id}/category": {
       "get": {
         "tags": [
           "Runs"
@@ -1744,7 +1602,7 @@
         }
       }
     },
-    "/run/{id}": {
+    "/runs/{id}": {
       "patch": {
         "tags": [
           "Runs"
@@ -1801,7 +1659,7 @@
             "description": "Unauthorized"
           },
           "403": {
-            "description": "The user attempted to update another user's run, or the user is banned or not yet confirmed.",
+            "description": "The user attempted to update another user's run, the user is banned or not yet confirmed, or the user attempted to change the status of a run.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1885,7 +1743,7 @@
         }
       }
     },
-    "/api/user/{id}": {
+    "/api/users/{id}": {
       "get": {
         "tags": [
           "Users"
@@ -1934,7 +1792,7 @@
         }
       }
     },
-    "/user/me": {
+    "/users/me": {
       "get": {
         "tags": [
           "Users"
@@ -2771,6 +2629,14 @@
               }
             ],
             "nullable": true
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Status"
+              }
+            ],
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -2786,6 +2652,14 @@
           },
           "info": {
             "type": "string"
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Status"
+              }
+            ],
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -2811,6 +2685,14 @@
             "format": "date",
             "nullable": true,
             "example": "2000-01-01"
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Status"
+              }
+            ],
+            "nullable": true
           }
         },
         "additionalProperties": false,


### PR DESCRIPTION
This PR normalizes URL path segment names to always be plural, does away with verbs in URL paths, combines the get Leaderboard by ID and the get Leaderboard by slug endpoints into one from the client's perspective, disallows purely numeric Leaderboard slugs, and deletes `/restore` routes in favor of allowing `Status` to be update via `PATCH` routes. Closes #331 