### PR TITLE
Add Leaderboard Stats

### DIFF
--- a/LeaderboardBackend.Test/Categories.cs
+++ b/LeaderboardBackend.Test/Categories.cs
@@ -287,8 +287,8 @@ internal class Categories
 
         resultWithDeleted.Data.Should().BeEquivalentTo(board.Categories, options => options.ExcludingMissingMembers());
         resultWithDeleted.Total.Should().Be(3);
-        board.Categories[0].DeletedAt = _clock.GetCurrentInstant();
-        board.Categories[1].DeletedAt = _clock.GetCurrentInstant();
+        board.Categories.ElementAt(0).DeletedAt = _clock.GetCurrentInstant();
+        board.Categories.ElementAt(1).DeletedAt = _clock.GetCurrentInstant();
         await context.SaveChangesAsync();
 
         ListView<CategoryViewModel> resultEmpty = await _apiClient.Get<ListView<CategoryViewModel>>(

--- a/LeaderboardBackend.Test/Leaderboards.cs
+++ b/LeaderboardBackend.Test/Leaderboards.cs
@@ -1238,7 +1238,7 @@ public class Leaderboards
         await context.SaveChangesAsync();
 
         _clock.Advance(Duration.FromDays(1));
-        leaderboard.Categories[1].Runs![1].DeletedAt = _clock.GetCurrentInstant();
+        leaderboard.Categories.Last().Runs.Last().DeletedAt = _clock.GetCurrentInstant();
         context.Leaderboards.Update(leaderboard);
         await context.SaveChangesAsync();
 

--- a/LeaderboardBackend.Test/Leaderboards.cs
+++ b/LeaderboardBackend.Test/Leaderboards.cs
@@ -1181,4 +1181,73 @@ public class Leaderboards
         resultsVerifyCount.Data.Should().ContainSingle();
         resultsVerifyCount.Total.Should().Be(2);
     }
+
+    [Test]
+    public async Task GetLeaderboardWithStats_OK()
+    {
+        using IServiceScope serviceScope = _factory.Services.CreateScope();
+        using ApplicationContext context = serviceScope.ServiceProvider.GetRequiredService<ApplicationContext>();
+
+        Leaderboard leaderboard = new()
+        {
+            Name = "Grand Theft Auto: Vice City",
+            Info = "All you had to do was follow the damn train!",
+            Slug = "vice-city",
+            Categories = [
+                new()
+                {
+                    Name = "All Missions",
+                    Slug = "all-missions",
+                    SortDirection = SortDirection.Ascending,
+                    Type = RunType.Time,
+                    Runs = [
+                        new()
+                        {
+                            Time = Duration.FromMinutes(120.5),
+                            PlayedOn = LocalDate.FromDateTime(_clock.GetCurrentInstant().ToDateTimeUtc()),
+                            UserId = TestInitCommonFields.Admin.Id
+                        }
+                    ]
+                },
+                new()
+                {
+                    Name = "100%",
+                    Slug = "hundo",
+                    SortDirection = SortDirection.Ascending,
+                    Type = RunType.Time,
+                    Runs = [
+                        new()
+                        {
+                            Time = Duration.FromHours(4.2),
+                            PlayedOn = LocalDate.FromDateTime(_clock.GetCurrentInstant().ToDateTimeUtc()),
+                            UserId = TestInitCommonFields.Admin.Id
+                        },
+                        new()
+                        {
+                            Time = Duration.FromHours(2),
+                            PlayedOn = LocalDate.FromDateTime(_clock.GetCurrentInstant().ToDateTimeUtc()),
+                            UserId = TestInitCommonFields.Admin.Id,
+                            Info = "Whoops didn't mean to submit this."
+                        }
+                    ]
+                }
+            ]
+        };
+
+        context.Leaderboards.Add(leaderboard);
+        await context.SaveChangesAsync();
+
+        _clock.Advance(Duration.FromDays(1));
+        leaderboard.Categories[1].Runs![1].DeletedAt = _clock.GetCurrentInstant();
+        context.Leaderboards.Update(leaderboard);
+        await context.SaveChangesAsync();
+
+        LeaderboardViewModel lbVieWModel = await _apiClient.Get<LeaderboardViewModel>(
+            $"/api/leaderboards/{leaderboard.Id}",
+            new()
+        );
+
+        lbVieWModel.Should().BeEquivalentTo(leaderboard, config => config.ExcludingMissingMembers());
+        lbVieWModel.Stats.RunCount.Should().Be(2);
+    }
 }

--- a/LeaderboardBackend/Controllers/LeaderboardsController.cs
+++ b/LeaderboardBackend/Controllers/LeaderboardsController.cs
@@ -65,7 +65,7 @@ public class LeaderboardsController(
         ListResult<LeaderboardWithStats> result = await leaderboardService.ListLeaderboards(status, page, sortBy);
         return Ok(new ListView<LeaderboardViewModel>()
         {
-            Data = [..result.Items.Select(LeaderboardViewModel.MapFrom)],
+            Data = [.. result.Items.Select(LeaderboardViewModel.MapFrom)],
             Total = result.ItemsTotal
         });
     }
@@ -94,7 +94,7 @@ public class LeaderboardsController(
 
         return Ok(new ListView<LeaderboardViewModel>()
         {
-            Data = [..result.Items.Select(LeaderboardViewModel.MapFrom)],
+            Data = [.. result.Items.Select(LeaderboardViewModel.MapFrom)],
             Total = result.ItemsTotal
         });
     }

--- a/LeaderboardBackend/Controllers/LeaderboardsController.cs
+++ b/LeaderboardBackend/Controllers/LeaderboardsController.cs
@@ -23,7 +23,7 @@ public class LeaderboardsController(
     [SwaggerResponse(404)]
     public async Task<ActionResult<LeaderboardViewModel>> GetLeaderboard([FromRoute] long id)
     {
-        Leaderboard? leaderboard = await leaderboardService.GetLeaderboard(id);
+        LeaderboardWithStats? leaderboard = await leaderboardService.GetLeaderboard(id);
 
         if (leaderboard == null)
         {
@@ -40,7 +40,7 @@ public class LeaderboardsController(
     [SwaggerResponse(404)]
     public async Task<ActionResult<LeaderboardViewModel>> GetLeaderboardBySlug([FromRoute] string slug)
     {
-        Leaderboard? leaderboard = await leaderboardService.GetLeaderboardBySlug(slug);
+        LeaderboardWithStats? leaderboard = await leaderboardService.GetLeaderboardBySlug(slug);
 
         if (leaderboard == null)
         {
@@ -62,10 +62,10 @@ public class LeaderboardsController(
         [FromQuery, SwaggerParameter("Sorts results by a leaderboard's field, tie-breaking with IDs if needed.")] SortLeaderboardsBy sortBy = SortLeaderboardsBy.Name_Asc
     )
     {
-        ListResult<Leaderboard> result = await leaderboardService.ListLeaderboards(status, page, sortBy);
+        ListResult<LeaderboardWithStats> result = await leaderboardService.ListLeaderboards(status, page, sortBy);
         return Ok(new ListView<LeaderboardViewModel>()
         {
-            Data = result.Items.Select(LeaderboardViewModel.MapFrom).ToList(),
+            Data = [..result.Items.Select(LeaderboardViewModel.MapFrom)],
             Total = result.ItemsTotal
         });
     }
@@ -90,11 +90,11 @@ public class LeaderboardsController(
             return Problem(null, null, 422, "Empty Query");
         }
 
-        ListResult<Leaderboard> result = await leaderboardService.SearchLeaderboards(query, status, page);
+        ListResult<LeaderboardWithStats> result = await leaderboardService.SearchLeaderboards(query, status, page);
 
         return Ok(new ListView<LeaderboardViewModel>()
         {
-            Data = result.Items.Select(LeaderboardViewModel.MapFrom).ToList(),
+            Data = [..result.Items.Select(LeaderboardViewModel.MapFrom)],
             Total = result.ItemsTotal
         });
     }

--- a/LeaderboardBackend/Models/Entities/Category.cs
+++ b/LeaderboardBackend/Models/Entities/Category.cs
@@ -80,6 +80,8 @@ public class Category : IHasUpdateTimestamp, IHasDeletionTimestamp
     ///     The time at which the Category was deleted, or <see langword="null" /> if the Category has not been deleted.
     /// </summary>
     public Instant? DeletedAt { get; set; }
+
+    public List<Run>? Runs { get; set; }
 }
 
 public class CategoryEntityTypeConfig : IEntityTypeConfiguration<Category>

--- a/LeaderboardBackend/Models/Entities/Category.cs
+++ b/LeaderboardBackend/Models/Entities/Category.cs
@@ -81,7 +81,7 @@ public class Category : IHasUpdateTimestamp, IHasDeletionTimestamp
     /// </summary>
     public Instant? DeletedAt { get; set; }
 
-    public List<Run>? Runs { get; set; }
+    public ICollection<Run> Runs { get; set; } = [];
 }
 
 public class CategoryEntityTypeConfig : IEntityTypeConfiguration<Category>

--- a/LeaderboardBackend/Models/Entities/Leaderboard.cs
+++ b/LeaderboardBackend/Models/Entities/Leaderboard.cs
@@ -28,7 +28,9 @@ public enum SortLeaderboardsBy
     /// <summary>
     /// Sorts by creation timestamp, latest-first.
     /// </summary>
-    CreatedAt_Desc
+    CreatedAt_Desc,
+    RunCount_Asc,
+    RunCount_Desc
 }
 
 /// <summary>

--- a/LeaderboardBackend/Models/Entities/Leaderboard.cs
+++ b/LeaderboardBackend/Models/Entities/Leaderboard.cs
@@ -92,6 +92,18 @@ public class Leaderboard : IHasUpdateTimestamp, IHasDeletionTimestamp
     public List<Category>? Categories { get; set; }
 }
 
+public class LeaderboardStats
+{
+    public long RunCount { get; set; }
+}
+
+public class LeaderboardWithStats
+{
+    public required Leaderboard Leaderboard { get; set; }
+
+    public required LeaderboardStats Stats { get; set; }
+}
+
 public static class LeaderboardExtensions
 {
     /// <summary>

--- a/LeaderboardBackend/Models/Entities/Leaderboard.cs
+++ b/LeaderboardBackend/Models/Entities/Leaderboard.cs
@@ -97,11 +97,13 @@ public class LeaderboardStats
     public long RunCount { get; set; }
 }
 
-public class LeaderboardWithStats
+public class LeaderboardWithStats : ICounts<long>
 {
     public required Leaderboard Leaderboard { get; set; }
 
     public required LeaderboardStats Stats { get; set; }
+
+    public long Count { get; set; }
 }
 
 public static class LeaderboardExtensions

--- a/LeaderboardBackend/Models/Entities/Leaderboard.cs
+++ b/LeaderboardBackend/Models/Entities/Leaderboard.cs
@@ -89,7 +89,7 @@ public class Leaderboard : IHasUpdateTimestamp, IHasDeletionTimestamp
     /// <summary>
     ///     A collection of `Category` entities for the `Leaderboard`.
     /// </summary>
-    public List<Category>? Categories { get; set; }
+    public ICollection<Category> Categories { get; set; } = [];
 }
 
 public class LeaderboardStats

--- a/LeaderboardBackend/Models/Entities/Run.cs
+++ b/LeaderboardBackend/Models/Entities/Run.cs
@@ -73,7 +73,7 @@ public class Run : IHasUpdateTimestamp, IHasDeletionTimestamp
     public User User { get; set; } = null!;
 }
 
-public class RankedRun
+public class RankedRun : ICounts<long>
 {
     public Run Run { get; set; } = null!;
     public long Rank { get; set; }

--- a/LeaderboardBackend/Models/ICounts.cs
+++ b/LeaderboardBackend/Models/ICounts.cs
@@ -1,0 +1,8 @@
+using System.Numerics;
+
+namespace LeaderboardBackend.Models;
+
+public interface ICounts<TBinInt> where TBinInt : IBinaryInteger<TBinInt>
+{
+    TBinInt Count { get; set; }
+}

--- a/LeaderboardBackend/Models/ViewModels/LeaderboardViewModel.cs
+++ b/LeaderboardBackend/Models/ViewModels/LeaderboardViewModel.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using LeaderboardBackend.Models.Entities;
 using NodaTime;
 
@@ -50,6 +51,9 @@ public record LeaderboardViewModel
 
     public required Status Status { get; set; }
 
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public LeaderboardStats Stats { get; set; } = null!;
+
     public static LeaderboardViewModel MapFrom(Leaderboard leaderboard) => new()
     {
         Id = leaderboard.Id,
@@ -61,4 +65,11 @@ public record LeaderboardViewModel
         DeletedAt = leaderboard.DeletedAt,
         Status = leaderboard.Status()
     };
+
+    public static LeaderboardViewModel MapFrom(LeaderboardWithStats lbWithStats)
+    {
+        LeaderboardViewModel viewModel = MapFrom(lbWithStats.Leaderboard);
+        viewModel.Stats = lbWithStats.Stats;
+        return viewModel;
+    }
 }

--- a/LeaderboardBackend/Results.cs
+++ b/LeaderboardBackend/Results.cs
@@ -1,5 +1,7 @@
 using OneOf;
 using OneOf.Types;
+using LeaderboardBackend.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace LeaderboardBackend.Result;
 
@@ -37,3 +39,12 @@ public partial class UpdateResult<T> : OneOfBase<Conflict<T>, NotFound, Success>
 
 [GenerateOneOf]
 public partial class RestoreResult<T> : OneOfBase<T, NotFound, NeverDeleted, Conflict<T>>;
+
+public static class IQueryableListResultExtensions
+{
+    public static async Task<ListResult<T>> ToListResult<T>(this IQueryable<T> queryable) where T : ICounts<long>
+    {
+        List<T> result = await queryable.ToListAsync();
+        return new(result, result.FirstOrDefault()?.Count ?? 0L);
+    }
+}

--- a/LeaderboardBackend/Results.cs
+++ b/LeaderboardBackend/Results.cs
@@ -1,7 +1,7 @@
-using OneOf;
-using OneOf.Types;
 using LeaderboardBackend.Models;
 using Microsoft.EntityFrameworkCore;
+using OneOf;
+using OneOf.Types;
 
 namespace LeaderboardBackend.Result;
 

--- a/LeaderboardBackend/Services/ILeaderboardService.cs
+++ b/LeaderboardBackend/Services/ILeaderboardService.cs
@@ -7,14 +7,14 @@ namespace LeaderboardBackend.Services;
 
 public interface ILeaderboardService
 {
-    Task<Leaderboard?> GetLeaderboard(long id);
-    Task<Leaderboard?> GetLeaderboardBySlug(string slug);
-    Task<ListResult<Leaderboard>> ListLeaderboards(StatusFilter statusFilter, Page page, SortLeaderboardsBy sortBy);
+    Task<LeaderboardWithStats?> GetLeaderboard(long id);
+    Task<LeaderboardWithStats?> GetLeaderboardBySlug(string slug);
+    Task<ListResult<LeaderboardWithStats>> ListLeaderboards(StatusFilter statusFilter, Page page, SortLeaderboardsBy sortBy);
     Task<CreateLeaderboardResult> CreateLeaderboard(CreateLeaderboardRequest request);
-    Task<RestoreResult<Leaderboard>> RestoreLeaderboard(long id);
+    Task<RestoreResult<LeaderboardWithStats>> RestoreLeaderboard(long id);
     Task<DeleteResult> DeleteLeaderboard(long id);
     Task<UpdateResult<Leaderboard>> UpdateLeaderboard(long id, UpdateLeaderboardRequest request);
-    Task<ListResult<Leaderboard>> SearchLeaderboards(string query, StatusFilter statusFilter, Page page);
+    Task<ListResult<LeaderboardWithStats>> SearchLeaderboards(string query, StatusFilter statusFilter, Page page);
 }
 
 [GenerateOneOf]

--- a/LeaderboardBackend/Services/Impl/LeaderboardService.cs
+++ b/LeaderboardBackend/Services/Impl/LeaderboardService.cs
@@ -30,6 +30,8 @@ public class LeaderboardService(ApplicationContext applicationContext, IClock cl
             SortLeaderboardsBy.Name_Desc => query.OrderByDescending(lb => lb.Leaderboard.Name),
             SortLeaderboardsBy.CreatedAt_Asc => query.OrderBy(lb => lb.Leaderboard.CreatedAt),
             SortLeaderboardsBy.CreatedAt_Desc => query.OrderByDescending(lb => lb.Leaderboard.CreatedAt),
+            SortLeaderboardsBy.RunCount_Asc => query.OrderBy(lb => lb.Stats.RunCount),
+            SortLeaderboardsBy.RunCount_Desc => query.OrderByDescending(lb => lb.Stats.RunCount),
             _ => throw new InvalidEnumArgumentException(nameof(SortLeaderboardsBy), (int)sortBy, typeof(SortLeaderboardsBy)),
         };
 

--- a/LeaderboardBackend/Services/Impl/LeaderboardService.cs
+++ b/LeaderboardBackend/Services/Impl/LeaderboardService.cs
@@ -12,32 +12,31 @@ namespace LeaderboardBackend.Services;
 
 public class LeaderboardService(ApplicationContext applicationContext, IClock clock) : ILeaderboardService
 {
-    public async Task<Leaderboard?> GetLeaderboard(long id) =>
-        await applicationContext.Leaderboards.FindAsync(id);
+    public async Task<LeaderboardWithStats?> GetLeaderboard(long id) =>
+        await applicationContext.Leaderboards.WithStats().FirstOrDefaultAsync(lb => lb.Leaderboard.Id == id);
 
-    public async Task<Leaderboard?> GetLeaderboardBySlug(string slug) =>
+    public async Task<LeaderboardWithStats?> GetLeaderboardBySlug(string slug) =>
         await applicationContext.Leaderboards
-            .FirstOrDefaultAsync(b => b.Slug == slug && b.DeletedAt == null);
+            .WithStats()
+            .FirstOrDefaultAsync(b => b.Leaderboard.Slug == slug && b.Leaderboard.DeletedAt == null);
 
-    public async Task<ListResult<Leaderboard>> ListLeaderboards(StatusFilter statusFilter, Page page, SortLeaderboardsBy sortBy)
+    public async Task<ListResult<LeaderboardWithStats>> ListLeaderboards(StatusFilter statusFilter, Page page, SortLeaderboardsBy sortBy)
     {
-        IQueryable<Leaderboard> query = applicationContext.Leaderboards.FilterByStatus(statusFilter);
-        long count = await query.LongCountAsync();
+        IQueryable<LeaderboardWithStats> query = applicationContext.Leaderboards.FilterByStatus(statusFilter).WithStatsAndCount();
 
         query = sortBy switch
         {
-            SortLeaderboardsBy.Name_Asc => query.OrderBy(lb => lb.Name),
-            SortLeaderboardsBy.Name_Desc => query.OrderByDescending(lb => lb.Name),
-            SortLeaderboardsBy.CreatedAt_Asc => query.OrderBy(lb => lb.CreatedAt),
-            SortLeaderboardsBy.CreatedAt_Desc => query.OrderByDescending(lb => lb.CreatedAt),
+            SortLeaderboardsBy.Name_Asc => query.OrderBy(lb => lb.Leaderboard.Name),
+            SortLeaderboardsBy.Name_Desc => query.OrderByDescending(lb => lb.Leaderboard.Name),
+            SortLeaderboardsBy.CreatedAt_Asc => query.OrderBy(lb => lb.Leaderboard.CreatedAt),
+            SortLeaderboardsBy.CreatedAt_Desc => query.OrderByDescending(lb => lb.Leaderboard.CreatedAt),
             _ => throw new InvalidEnumArgumentException(nameof(SortLeaderboardsBy), (int)sortBy, typeof(SortLeaderboardsBy)),
         };
 
-        List<Leaderboard> items = await query
+        return await query
             .Skip(page.Offset)
             .Take(page.Limit)
-            .ToListAsync();
-        return new ListResult<Leaderboard>(items, count);
+            .ToListResult();
     }
 
     public async Task<CreateLeaderboardResult> CreateLeaderboard(CreateLeaderboardRequest request)
@@ -64,21 +63,21 @@ public class LeaderboardService(ApplicationContext applicationContext, IClock cl
         return lb;
     }
 
-    public async Task<RestoreResult<Leaderboard>> RestoreLeaderboard(long id)
+    public async Task<RestoreResult<LeaderboardWithStats>> RestoreLeaderboard(long id)
     {
-        Leaderboard? lb = await applicationContext.Leaderboards.FindAsync(id);
+        LeaderboardWithStats? lb = await applicationContext.Leaderboards.WithStats().FirstOrDefaultAsync(lb => lb.Leaderboard.Id == id);
 
         if (lb == null)
         {
             return new NotFound();
         }
 
-        if (lb.DeletedAt == null)
+        if (lb.Leaderboard.DeletedAt == null)
         {
             return new NeverDeleted();
         }
 
-        lb.DeletedAt = null;
+        lb.Leaderboard.DeletedAt = null;
 
         try
         {
@@ -87,8 +86,11 @@ public class LeaderboardService(ApplicationContext applicationContext, IClock cl
         catch (DbUpdateException e)
             when (e.InnerException is PostgresException { SqlState: PostgresErrorCodes.UniqueViolation } pgEx)
         {
-            Leaderboard conflict = await applicationContext.Leaderboards.SingleAsync(c => c.Slug == lb.Slug && c.DeletedAt == null);
-            return new Conflict<Leaderboard>(conflict);
+            LeaderboardWithStats conflict = await applicationContext.Leaderboards.WithStats().SingleAsync(
+                c => c.Leaderboard.Slug == lb.Leaderboard.Slug && c.Leaderboard.DeletedAt == null
+            );
+
+            return new Conflict<LeaderboardWithStats>(conflict);
         }
 
         return lb;
@@ -96,6 +98,10 @@ public class LeaderboardService(ApplicationContext applicationContext, IClock cl
 
     public async Task<DeleteResult> DeleteLeaderboard(long id)
     {
+        // TODO: Use ExecuteUpdate instead of fetching and saving, possibly using
+        // RETURNING to check old value.
+        // - Ted W
+
         Leaderboard? lb = await applicationContext.Leaderboards.FindAsync(id);
 
         if (lb is null)
@@ -173,17 +179,14 @@ public class LeaderboardService(ApplicationContext applicationContext, IClock cl
 
         return new Success();
     }
-    public async Task<ListResult<Leaderboard>> SearchLeaderboards(string query, StatusFilter statusFilter, Page page)
-    {
-        IQueryable<Leaderboard> dbQuery = applicationContext.Leaderboards.FilterByStatus(statusFilter).Search(query);
-        long count = await dbQuery.LongCountAsync();
 
-        List<Leaderboard> items = await dbQuery
+    public async Task<ListResult<LeaderboardWithStats>> SearchLeaderboards(string query, StatusFilter statusFilter, Page page) =>
+        await applicationContext.Leaderboards
+            .FilterByStatus(statusFilter)
+            .Search(query)
             .Rank(query)
             .Skip(page.Offset)
             .Take(page.Limit)
-            .ToListAsync();
-
-        return new ListResult<Leaderboard>(items, count);
-    }
+            .WithStatsAndCount()
+            .ToListResult();
 }

--- a/LeaderboardBackend/Services/Impl/RunService.cs
+++ b/LeaderboardBackend/Services/Impl/RunService.cs
@@ -106,15 +106,13 @@ public class RunService(ApplicationContext applicationContext, IClock clock) : I
             runs = query.OrderByDescending(r => r.Run.TimeOrScore);
         }
 
-        List<RankedRun> records = await runs
+        return await runs
             .ThenBy(r => r.Run.PlayedOn)
             .ThenBy(r => r.Run.CreatedAt)
             .ThenBy(r => r.Run.Id)
             .Skip(page.Offset)
             .Take(page.Limit)
-            .ToListAsync();
-
-        return new ListResult<RankedRun>(records, records.FirstOrDefault()?.Count ?? 0L);
+            .ToListResult();
     }
 
     public async Task<CreateRunResult> CreateRun(User user, Category category, CreateRunRequest request)

--- a/LeaderboardBackend/openapi.json
+++ b/LeaderboardBackend/openapi.json
@@ -2397,6 +2397,16 @@
         ],
         "description": "`runType: \"Time\"`"
       },
+      "LeaderboardStats": {
+        "type": "object",
+        "properties": {
+          "runCount": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "additionalProperties": false
+      },
       "LeaderboardViewModel": {
         "required": [
           "createdAt",
@@ -2454,6 +2464,13 @@
             "allOf": [
               {
                 "$ref": "#/components/schemas/Status"
+              }
+            ]
+          },
+          "stats": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LeaderboardStats"
               }
             ]
           }
@@ -2821,7 +2838,9 @@
           "Name_Asc",
           "Name_Desc",
           "CreatedAt_Asc",
-          "CreatedAt_Desc"
+          "CreatedAt_Desc",
+          "RunCount_Asc",
+          "RunCount_Desc"
         ],
         "type": "string",
         "description": "Used in GetLeaderboards to sort leaderboards by a field."


### PR DESCRIPTION
This PR makes it so that querying a leaderboard also returns a number indicating how many runs are on that board total. Deleted runs and runs belonging to deleted cats are not counted.